### PR TITLE
Disable instancing and use better filenames

### DIFF
--- a/CesiumIonRevitAddin/Preferences.cs
+++ b/CesiumIonRevitAddin/Preferences.cs
@@ -15,7 +15,7 @@ namespace CesiumIonRevitAddin
         public bool Properties { get; set; }
         public bool RelocateTo0 { get; set; }
         public bool FlipAxis { get; set; } = true;
-        public bool Instancing { get; set; } = true;
+        public bool Instancing { get; set; } = false;
         public bool TrueNorth { get; set; } = true;
         public bool SharedCoordinates { get; set; } = true;
         public string EpsgCode { get; set; } = "";

--- a/CesiumIonRevitAddin/Utils/IonExportUtils.cs
+++ b/CesiumIonRevitAddin/Utils/IonExportUtils.cs
@@ -24,6 +24,13 @@ namespace CesiumIonRevitAddin.Utils
             else
                 preferences = new Preferences();
 
+            // Use the existing filename for the first export instead of the default tileset.3dtiles
+            if (!existingPreferences && doc.PathName != "")
+            {
+                string docFileName = Path.GetFileNameWithoutExtension(doc.PathName);
+                preferences.OutputPath = Path.Combine(preferences.OutputDirectory, docFileName + ".3dtiles");
+            }
+
             // Display the export preferences dialog
             using (ExportDialog exportDialog = new ExportDialog(ref preferences))
             {


### PR DESCRIPTION
This PR disables instancing by default

It also provides a better default filename for first time exports of existing .RVT files