### PR TITLE
Prevent export of families

### DIFF
--- a/CesiumIonRevitAddin/Utils/IonExportUtils.cs
+++ b/CesiumIonRevitAddin/Utils/IonExportUtils.cs
@@ -51,9 +51,15 @@ namespace CesiumIonRevitAddin.Utils
 
         public static View3D GetExportView(Autodesk.Revit.DB.View view)
         {
+            if (view.Document.IsFamilyDocument)
+            {
+                Autodesk.Revit.UI.TaskDialog.Show("Families Not Supported", "Families cannot be uploaded to Cesium ion. Please open a project document and try again.");
+                return null;
+            }
+
             if (view.GetType().Name != "View3D")
             {
-                Autodesk.Revit.UI.TaskDialog.Show("Wrong View", "You must be in a 3D view to export");
+                Autodesk.Revit.UI.TaskDialog.Show("3D View Required", "A 3D view is required to upload to Cesium ion. Please switch to a 3D view and try again.");
                 return null;
             }
             return (View3D)view;


### PR DESCRIPTION
This PR adds an additional check to the currently selected view to determine if it belongs to a project or a family.

If it belongs to a family, an error is displayed to the user requesting them to open a project document.

This PR also updates the 3D View error to be more specific to uploading terminology.

We could theoretically support families in the future, however we do reference project specific code in many places and we've not had feedback from users requesting the ability to export families yet.

Closes #100 