### PR TITLE
handle name collisions with physical and render material properties

### DIFF
--- a/CesiumIonRevitAddin/Export/RevitMaterials.cs
+++ b/CesiumIonRevitAddin/Export/RevitMaterials.cs
@@ -501,7 +501,8 @@ namespace CesiumIonRevitAddin.Export
                     {
                         // A property from the Appearance can have the same name as one from the physical Material.
                         // For example, "category".
-                        gltfPropertyName = "render" + char.ToUpper(gltfPropertyName[0]) + gltfPropertyName.Substring(1);
+                        gltfPropertyName = string.Concat("render", char.ToUpper(gltfPropertyName[0]), gltfPropertyName.Substring(1));
+
                         if (!gltfMaterial.Extensions.EXT_structural_metadata.Properties.ContainsKey(gltfPropertyName))
                         {
                             gltfMaterial.Extensions.EXT_structural_metadata.Properties.Add(gltfPropertyName, assetPropertyString.Value);


### PR DESCRIPTION
It's possible for a physical material (`Material` class) to have properties with the same name as the render material (`Appearance` class.) In Snowden, a `Material` often has `category` and `description` properties, while the associated `Appearance` also has them. Since in the glTF metadata the name must be unique, we need to resolve name collisions. This solution appends "render" to the property name if there is a name collision and the property is from a Revit rendering asset.

E.g:

```
                "EXT_structural_metadata": {
                    "class": "metalPanels50x60White",
                    "properties": {
                        ...
                        "category": "-2000700",
                        ...
                        "description": "Metal panels",
                        "renderCategory": "::Siding:Default",
                        "renderDescription": "Metal Panels - White",
```