### PR TITLE
Handle materials with the same name

### DIFF
--- a/CesiumIonRevitAddin/Export/RevitMaterials.cs
+++ b/CesiumIonRevitAddin/Export/RevitMaterials.cs
@@ -150,7 +150,7 @@ namespace CesiumIonRevitAddin.Export
                             string paramGltfName = Utils.Util.GetGltfName(paramName);
 
                             if (parameter.HasValue && !gltfMaterial.Extensions.EXT_structural_metadata.Properties.ContainsKey(paramGltfName))
-                                {
+                            {
                                 gltfMaterial.Extensions.EXT_structural_metadata.Properties.Add(paramGltfName, paramValue);
                                 AddParameterToClassSchema(parameter, classSchema);
                             }


### PR DESCRIPTION
Two Revit materials with different IDs can have the same name. This caused a collision issue when exporting glTF. This patch resolves the collision.