### PR TITLE
Add verbose logging

### DIFF
--- a/CesiumIonRevitAddin/Export/RevitMaterials.cs
+++ b/CesiumIonRevitAddin/Export/RevitMaterials.cs
@@ -109,6 +109,8 @@ namespace CesiumIonRevitAddin.Export
                 return;
             }
 
+            if (preferences.VerboseLogging) Logger.Instance.Log("Exporting MaterialId " + id.ToString());
+
             string uniqueId;
             if (materialIdDictionary.TryGetValue(id, out GltfMaterial gltfMaterial))
             {

--- a/CesiumIonRevitAddin/Preferences.cs
+++ b/CesiumIonRevitAddin/Preferences.cs
@@ -36,6 +36,7 @@ namespace CesiumIonRevitAddin
         public string GltfPath => Path.Combine(TempDirectory, "tileset.gltf");
         public string Temp3DTilesPath => Path.Combine(TempDirectory, OutputFilename);
         public bool ionExport { get; set; } = false;
+        public bool VerboseLogging { get; } = false;
 
         public string ToJson() => JsonConvert.SerializeObject(this, Formatting.Indented);
 

--- a/CesiumIonRevitAddin/gltf/GltfExportContext.cs
+++ b/CesiumIonRevitAddin/gltf/GltfExportContext.cs
@@ -728,6 +728,8 @@ namespace CesiumIonRevitAddin.Gltf
 
         public void OnMaterial(MaterialNode node)
         {
+            if (preferences.VerboseLogging) Logger.Instance.Log("Beginning OnMaterial...");
+
             materialHasTexture = false;
             if (preferences.Materials)
             {
@@ -746,6 +748,7 @@ namespace CesiumIonRevitAddin.Gltf
                     khrTextureTransformAdded = true;
                 }
             }
+            if (preferences.VerboseLogging) Logger.Instance.Log("...ending OnMaterial");
         }
 
         public class SerializableTransform
@@ -795,6 +798,7 @@ namespace CesiumIonRevitAddin.Gltf
 
         public void OnPolymesh(PolymeshTopology node)
         {
+            if (preferences.VerboseLogging) Logger.Instance.Log("Beginning OnPolymesh...");
             GltfExportUtils.AddOrUpdateCurrentItem(nodes, currentGeometry, currentVertices, materials);
 
             var pts = node.GetPoints();
@@ -849,6 +853,8 @@ namespace CesiumIonRevitAddin.Gltf
             {
                 GltfExportUtils.AddTexCoords(preferences, node, currentGeometry.CurrentItem.TexCoords);
             }
+
+            if (preferences.VerboseLogging) Logger.Instance.Log("...ending OnPolymesh");
         }
 
         RenderNodeAction IExportContext.OnViewBegin(ViewNode node)


### PR DESCRIPTION
Setting `VerboseLogging` to `true` in `Preferences` will output more logging to help debug issues. These include the IDs of materials being exported as well as statements showing when critical functions begin and end.