### PR TITLE
write out Element IDs as integers in glTF

### DIFF
--- a/CesiumIonRevitAddin/CesiumIonRevitAddin.projitems
+++ b/CesiumIonRevitAddin/CesiumIonRevitAddin.projitems
@@ -17,6 +17,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Export\BufferConfig.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Export\FileExport.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Export\GltfJson.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Export\ParameterValue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Export\RevitMaterials.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExternalApplication.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Forms\ExportDialog.cs" />

--- a/CesiumIonRevitAddin/Export/ParameterValue.cs
+++ b/CesiumIonRevitAddin/Export/ParameterValue.cs
@@ -1,0 +1,48 @@
+using Newtonsoft.Json;
+using System;
+
+[JsonConverter(typeof(ParameterValueConverter))]
+public struct ParameterValue
+{
+    public int? IntegerValue { get; set; }
+    public double? DoubleValue { get; set; }
+    public string StringValue { get; set; }
+    public long? LongValue { get; set; }
+
+    public static implicit operator ParameterValue(int value) => new ParameterValue { IntegerValue = value };
+    public static implicit operator ParameterValue(double value) => new ParameterValue { DoubleValue = value };
+    public static implicit operator ParameterValue(long value) => new ParameterValue { LongValue = value };
+    public static implicit operator ParameterValue(string value) => new ParameterValue { StringValue = value };
+}
+
+public class ParameterValueConverter : JsonConverter<ParameterValue>
+{
+    public override void WriteJson(JsonWriter writer, ParameterValue value, JsonSerializer serializer)
+    {
+        if (value.IntegerValue.HasValue)
+        {
+            writer.WriteValue(value.IntegerValue.Value);
+        }
+        else if (value.DoubleValue.HasValue)
+        {
+            writer.WriteValue(value.DoubleValue.Value);
+        }
+        else if (value.LongValue.HasValue)
+        {
+            writer.WriteValue(value.LongValue.Value);
+        }
+        else if (!string.IsNullOrEmpty(value.StringValue))
+        {
+            writer.WriteValue(value.StringValue);
+        }
+        else
+        {
+            writer.WriteNull();
+        }
+    }
+
+    public override ParameterValue ReadJson(JsonReader reader, Type objectType, ParameterValue existingValue, bool hasExistingValue, JsonSerializer serializer)
+    {
+        throw new NotImplementedException("Deserialization is not supported for ParameterValue.");
+    }
+}

--- a/CesiumIonRevitAddin/Utils/Util.cs
+++ b/CesiumIonRevitAddin/Utils/Util.cs
@@ -108,13 +108,12 @@ namespace CesiumIonRevitAddin.Utils
         {
             return value == null || ShouldFilterMetadata(value.ToString());
         }
-
         public static bool ShouldFilterMetadata(string value)
         {
             return _metaDataFilterValues.Contains(value);
         }
 
-        public static object GetParameterValue(Autodesk.Revit.DB.Parameter parameter)
+        public static ParameterValue GetParameterValue(Autodesk.Revit.DB.Parameter parameter)
         {
             switch (parameter.StorageType)
             {
@@ -125,9 +124,9 @@ namespace CesiumIonRevitAddin.Utils
                 case StorageType.String:
                     return parameter.AsString();
                 case StorageType.ElementId:
-                    return Util.GetElementIdAsLong(parameter.AsElementId()).ToString();
+                    return Util.GetElementIdAsLong(parameter.AsElementId());
                 default:
-                    return null;
+                    return new ParameterValue();
             }
         }
     }

--- a/CesiumIonRevitAddin/gltf/GltfExportContext.cs
+++ b/CesiumIonRevitAddin/gltf/GltfExportContext.cs
@@ -365,7 +365,7 @@ namespace CesiumIonRevitAddin.Gltf
                 foreach (Parameter parameter in parameterSet)
                 {
                     string propertyName = Util.GetGltfName(parameter.Definition.Name);
-                    object paramValue = Util.GetParameterValue(parameter);
+                    ParameterValue paramValue = Util.GetParameterValue(parameter);
 
                     if (parameter.HasValue && 
                         !Util.ShouldFilterMetadata(paramValue) && 


### PR DESCRIPTION
Previously Revit parameters that were of type ElementId were written out as strings in the glTF metadata. These are now written out as integers. New output:

![image](https://github.com/user-attachments/assets/55a2f407-b804-4192-826e-a8ed7a1ed743)
