### PR TITLE
Add human-readable metadata

### DIFF
--- a/CesiumIonRevitAddin/Export/RevitMaterials.cs
+++ b/CesiumIonRevitAddin/Export/RevitMaterials.cs
@@ -146,6 +146,7 @@ namespace CesiumIonRevitAddin.Export
                         if (parameter.HasValue)
                         {
                             string paramName = parameter.Definition.Name;
+
                             ParameterValue paramValue = Util.GetParameterValue(parameter);
 
                             if (Util.ShouldFilterMetadata(paramValue)) continue;
@@ -567,13 +568,11 @@ namespace CesiumIonRevitAddin.Export
                         propertySchema.Add("componentType", "FLOAT32");
                         break;
                     case StorageType.Integer:
+                    case StorageType.ElementId:
                         propertySchema.Add("type", "SCALAR");
                         propertySchema.Add("componentType", "INT32");
                         break;
                     case StorageType.String:
-                        propertySchema.Add("type", "STRING");
-                        break;
-                    case StorageType.ElementId:
                         propertySchema.Add("type", "STRING");
                         break;
                     default:

--- a/CesiumIonRevitAddin/Export/RevitMaterials.cs
+++ b/CesiumIonRevitAddin/Export/RevitMaterials.cs
@@ -146,7 +146,8 @@ namespace CesiumIonRevitAddin.Export
                         if (parameter.HasValue)
                         {
                             string paramName = parameter.Definition.Name;
-                            object paramValue = Util.GetParameterValue(parameter);
+                            ParameterValue paramValue = Util.GetParameterValue(parameter);
+
                             if (Util.ShouldFilterMetadata(paramValue)) continue;
 
                             string paramGltfName = Utils.Util.GetGltfName(paramName);

--- a/CesiumIonRevitAddin/Export/RevitMaterials.cs
+++ b/CesiumIonRevitAddin/Export/RevitMaterials.cs
@@ -2,11 +2,9 @@
 using Autodesk.Revit.DB.Visual;
 using CesiumIonRevitAddin.Gltf;
 using CesiumIonRevitAddin.Utils;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace CesiumIonRevitAddin.Export
 {

--- a/CesiumIonRevitAddin/Utils/Util.cs
+++ b/CesiumIonRevitAddin/Utils/Util.cs
@@ -103,7 +103,7 @@ namespace CesiumIonRevitAddin.Utils
 #endif
         }
 
-        static HashSet<string> metadataFilterValues = new HashSet<string> { "", "-1" };
+        static readonly HashSet<string> metadataFilterValues = new HashSet<string> { "", "-1" };
         public static bool ShouldFilterMetadata(ParameterValue parameterValue)
         {
             if (parameterValue.IntegerValue.HasValue || parameterValue.DoubleValue.HasValue || parameterValue.LongValue.HasValue)

--- a/CesiumIonRevitAddin/Utils/Util.cs
+++ b/CesiumIonRevitAddin/Utils/Util.cs
@@ -103,14 +103,22 @@ namespace CesiumIonRevitAddin.Utils
 #endif
         }
 
-        static HashSet<string> _metaDataFilterValues = new HashSet<string> { "", "-1" };
-        public static bool ShouldFilterMetadata(object value)
+        static HashSet<string> metadataFilterValues = new HashSet<string> { "", "-1" };
+        public static bool ShouldFilterMetadata(ParameterValue parameterValue)
         {
-            return value == null || ShouldFilterMetadata(value.ToString());
+            if (parameterValue.IntegerValue.HasValue || parameterValue.DoubleValue.HasValue || parameterValue.LongValue.HasValue)
+            {
+                return false;
+            }
+            if (parameterValue.StringValue != null)
+            {
+                return ShouldFilterMetadata(parameterValue.StringValue);
+            }
+            return true;
         }
         public static bool ShouldFilterMetadata(string value)
         {
-            return _metaDataFilterValues.Contains(value);
+            return metadataFilterValues.Contains(value);
         }
 
         public static ParameterValue GetParameterValue(Autodesk.Revit.DB.Parameter parameter)

--- a/CesiumIonRevitAddin/gltf/GltfExportContext.cs
+++ b/CesiumIonRevitAddin/gltf/GltfExportContext.cs
@@ -10,9 +10,7 @@ using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
-using System.Windows.Media;
 using System.Windows.Media.Media3D;
-using System.Xml.Linq;
 
 namespace CesiumIonRevitAddin.Gltf
 {
@@ -47,7 +45,7 @@ namespace CesiumIonRevitAddin.Gltf
         private List<string> extensionsUsed = null;
         private List<string> extensionsRequired = null;
         private readonly Dictionary<string, GltfExtensionSchema> extensions = new Dictionary<string, GltfExtensionSchema>();
-        private readonly GltfExtStructuralMetadataExtensionSchema extStructuralMetadataSchema = new GltfExtStructuralMetadataExtensionSchema();
+        private readonly GltfExtStructuralMetadataExtensionSchema extStructuralMetadataExtensionSchema = new GltfExtStructuralMetadataExtensionSchema();
         private Autodesk.Revit.DB.Transform cachedTransform;
         private bool khrTextureTransformAdded;
         private bool skipElementFlag;
@@ -166,11 +164,11 @@ namespace CesiumIonRevitAddin.Gltf
             {
                 extensionsUsed = extensionsUsed ?? new List<string>();
                 extensionsUsed.Add("EXT_structural_metadata");
-                extensions.Add("EXT_structural_metadata", extStructuralMetadataSchema);
+                extensions.Add("EXT_structural_metadata", extStructuralMetadataExtensionSchema);
 
                 ProjectInfo projectInfo = Doc.ProjectInformation;
 
-                var rootSchema = extStructuralMetadataSchema.GetClass("project") ?? extStructuralMetadataSchema.AddClass("Project");
+                var rootSchema = extStructuralMetadataExtensionSchema.GetClass("project") ?? extStructuralMetadataExtensionSchema.AddClass("Project");
                 var rootSchemaProperties = new Dictionary<string, object>();
                 rootSchema.Add("properties", rootSchemaProperties);
 
@@ -239,9 +237,9 @@ namespace CesiumIonRevitAddin.Gltf
 #else
                             string categoryGltfName = CesiumIonRevitAddin.Utils.Util.GetGltfName(category.BuiltInCategory.ToString());
 #endif
-                            extStructuralMetadataSchema.AddCategory(categoryGltfName);
-                            var gltfClass = extStructuralMetadataSchema.GetClass(categoryGltfName);
-                            var schemaProperties = extStructuralMetadataSchema.GetProperties(gltfClass);
+                            extStructuralMetadataExtensionSchema.AddCategory(categoryGltfName);
+                            var gltfClass = extStructuralMetadataExtensionSchema.GetClass(categoryGltfName);
+                            var schemaProperties = extStructuralMetadataExtensionSchema.GetProperties(gltfClass);
                             string gltfDefinitionName = Util.GetGltfName(definition.Name);
                             if (schemaProperties.ContainsKey(gltfDefinitionName))
                             {
@@ -387,13 +385,13 @@ namespace CesiumIonRevitAddin.Gltf
                     }
                 }
 
-                extStructuralMetadataSchema.AddCategory(categoryName);
-                classMetadata = extStructuralMetadataSchema.AddFamily(categoryName, familyName);
-                extStructuralMetadataSchema.AddProperties(categoryName, familyName, parameterSet, parametersToSkip);
+                extStructuralMetadataExtensionSchema.AddCategory(categoryName);
+                classMetadata = extStructuralMetadataExtensionSchema.AddFamily(categoryName, familyName);
+                extStructuralMetadataExtensionSchema.AddProperties(categoryName, familyName, parameterSet, parametersToSkip);
 
                 // Add human-readable category and family names to schema as default properties.
-                extStructuralMetadataSchema.AddDefaultSchemaProperty(categoryName, familyName, "categoryName", categoryName, "Category Name");
-                extStructuralMetadataSchema.AddDefaultSchemaProperty(categoryName, familyName, "familyName", familyName, "Family Name");
+                extStructuralMetadataExtensionSchema.AddDefaultSchemaProperty(categoryName, familyName, "categoryName", categoryName, "Category Name");
+                extStructuralMetadataExtensionSchema.AddDefaultSchemaProperty(categoryName, familyName, "familyName", familyName, "Family Name");
 
                 // Add additional properties (e.g. 'name') to properties that are ElementIds
                 foreach (Parameter parameter in elementIdProperties)
@@ -421,7 +419,7 @@ namespace CesiumIonRevitAddin.Gltf
 
                             string propertyValue = parameterElement.Name;
                             newNode.Extensions.EXT_structural_metadata.AddProperty(resolvedPropertyName, propertyValue);
-                            extStructuralMetadataSchema.AddSchemaProperty(categoryName, familyName, resolvedPropertyName, propertyValue.GetType());
+                            extStructuralMetadataExtensionSchema.AddSchemaProperty(categoryName, familyName, resolvedPropertyName, propertyValue.GetType());
                         }
                     }
                 }
@@ -777,7 +775,7 @@ namespace CesiumIonRevitAddin.Gltf
             materialHasTexture = false;
             if (preferences.Materials)
             {
-                Export.RevitMaterials.Export(node, Doc, materials, extStructuralMetadataSchema, samplers, images, textures, ref materialHasTexture, preferences);
+                Export.RevitMaterials.Export(node, Doc, materials, extStructuralMetadataExtensionSchema, samplers, images, textures, ref materialHasTexture, preferences);
 
                 if (!preferences.Textures)
                 {

--- a/CesiumIonRevitAddin/gltf/GltfExportContext.cs
+++ b/CesiumIonRevitAddin/gltf/GltfExportContext.cs
@@ -277,7 +277,6 @@ namespace CesiumIonRevitAddin.Gltf
 
             // add to node
             var gltfPropertyName = Utils.Util.GetGltfName(propertyName);
-            // rootNode.Extensions.EXT_structural_metadata.Properties.Add(gltfPropertyName, propertyValue);
             rootNode.Extensions.EXT_structural_metadata.AddProperty(gltfPropertyName, propertyValue);
 
             // add to schema

--- a/CesiumIonRevitAddin/gltf/GltfExtStructuralMetadataExtensionSchema.cs
+++ b/CesiumIonRevitAddin/gltf/GltfExtStructuralMetadataExtensionSchema.cs
@@ -137,15 +137,14 @@ namespace CesiumIonRevitAddin.Gltf
                     {
                         case StorageType.None:
                             {
-
                                 schemaProperty.Add("type", "STRING");
                                 break;
                             }
                         case StorageType.String:
-                        case StorageType.ElementId:
                             schemaProperty.Add("type", "STRING");
                             break;
                         case StorageType.Integer:
+                        case StorageType.ElementId:
                             schemaProperty.Add("type", "SCALAR");
                             schemaProperty.Add("componentType", "INT32");
                             break;

--- a/CesiumIonRevitAddin/gltf/GltfExtStructuralMetadataExtensionSchema.cs
+++ b/CesiumIonRevitAddin/gltf/GltfExtStructuralMetadataExtensionSchema.cs
@@ -1,5 +1,6 @@
 ﻿using Autodesk.Revit.DB;
 using CesiumIonRevitAddin.Utils;
+using System;
 using System.Collections.Generic;
 
 namespace CesiumIonRevitAddin.Gltf
@@ -157,6 +158,61 @@ namespace CesiumIonRevitAddin.Gltf
                     }
 
                     schemaProperty.Add("required", IsRequired(parameter.Definition.Name));
+                }
+            }
+        }
+
+        public void AddDefaultSchemaProperty(string categoryName, string familyName, string propertyName, string defaultValue, string name)
+        {
+            var gltfClassName = Util.GetGltfName(Util.CreateClassName(categoryName, familyName));
+            ClassType gltfClass = GetClass(gltfClassName);
+            PropertiesType schemaProperties = GetProperties(gltfClass);
+            if (!schemaProperties.ContainsKey(propertyName))
+            {
+                schemaProperties.Add(propertyName, new PropertyType());
+                var schemaProperty = (PropertyType)schemaProperties[propertyName];
+                schemaProperty.Add("name", name);
+                schemaProperty.Add("type", "STRING");
+                schemaProperty.Add("default", defaultValue);
+            }
+        }
+
+        public void AddSchemaProperty(string categoryName, string familyName, string propertyName, Type propertyType)
+        {
+            var gltfClassName = Util.GetGltfName(Util.CreateClassName(categoryName, familyName));
+            ClassType gltfClass = GetClass(gltfClassName);
+            PropertiesType schemaProperties = GetProperties(gltfClass);
+            if (!schemaProperties.ContainsKey(propertyName))
+            {
+                var schemaProperty = new PropertyType();
+                schemaProperty.Add("name", propertyName);
+
+                bool typeHandled = true;
+
+                if (propertyType == typeof(string))
+                {
+                    schemaProperty.Add("type", "STRING");
+                }
+                else if (propertyType == typeof(int) || propertyType == typeof(bool))
+                {
+                    schemaProperty.Add("type", "SCALAR");
+                    schemaProperty.Add("componentType", "INT32");
+                }
+                else if (propertyType == typeof(double) || propertyType == typeof(float))
+                {
+                    schemaProperty.Add("type", "SCALAR");
+                    schemaProperty.Add("componentType", "FLOAT32");
+                } else
+                {
+                    typeHandled = false;
+                }
+
+                if (typeHandled)
+                {
+                    schemaProperties.Add(propertyName, schemaProperty);
+                } else
+                {
+                    Logger.Instance.Log("Error: Cannot handle parameter type " + propertyType + " for property " + propertyName);
                 }
             }
         }


### PR DESCRIPTION
Currently, glTF properties derived from Revit parameters that are an `ElementId` only output the ID of the Element. This leads to metadata that isn't particularly useful outside of Revit, such as this: `"category": -2000080`

This PR adds more human-readable properties to the glTF metadata.

An example:
![image](https://github.com/user-attachments/assets/eba4e8f1-bcac-4eb0-8b2a-73c67267d1c7)

In addition, some functions were added to more easily add glTF properties to metadata from Revit parameters.