### PR TITLE
Symbolic instance-based export

### DIFF
--- a/CesiumIonRevitAddin/Forms/ExportDialog.Designer.cs
+++ b/CesiumIonRevitAddin/Forms/ExportDialog.Designer.cs
@@ -42,7 +42,6 @@
             this.links = new System.Windows.Forms.CheckBox();
             this.materials = new System.Windows.Forms.CheckBox();
             this.textures = new System.Windows.Forms.CheckBox();
-            this.instancing = new System.Windows.Forms.CheckBox();
             this.cancelButton = new System.Windows.Forms.Button();
             this.exportButton = new System.Windows.Forms.Button();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
@@ -125,7 +124,6 @@
             this.groupBox1.Controls.Add(this.links);
             this.groupBox1.Controls.Add(this.materials);
             this.groupBox1.Controls.Add(this.textures);
-            this.groupBox1.Controls.Add(this.instancing);
             this.groupBox1.Location = new System.Drawing.Point(12, 98);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(310, 170);
@@ -204,18 +202,6 @@
             this.textures.UseVisualStyleBackColor = true;
             this.textures.CheckedChanged += new System.EventHandler(this.Textures_CheckedChanged);
             // 
-            // instancing
-            // 
-            this.instancing.AutoSize = true;
-            this.instancing.Location = new System.Drawing.Point(6, 111);
-            this.instancing.Name = "instancing";
-            this.instancing.Size = new System.Drawing.Size(101, 17);
-            this.instancing.TabIndex = 0;
-            this.instancing.Text = "GPU Instancing";
-            this.toolTip.SetToolTip(this.instancing, "Detects and uses instancing for eligible geometry on export. This can optimize re" +
-        "ndering performance and reduce memory usage.");
-            this.instancing.UseVisualStyleBackColor = true;
-            // 
             // cancelButton
             // 
             this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
@@ -279,7 +265,6 @@
         private System.Windows.Forms.RadioButton internalOrigin;
         private System.Windows.Forms.RadioButton sharedCoordinates;
         private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.CheckBox instancing;
         private System.Windows.Forms.Button cancelButton;
         private System.Windows.Forms.Button exportButton;
         private System.Windows.Forms.Label label1;

--- a/CesiumIonRevitAddin/Forms/ExportDialog.cs
+++ b/CesiumIonRevitAddin/Forms/ExportDialog.cs
@@ -24,7 +24,6 @@ namespace CesiumIonRevitAddin.Forms
             crsInput.Enabled = sharedCoordinates.Checked;
             crsInput.Text = this.preferences.EpsgCode;
 
-            instancing.Checked = this.preferences.Instancing;
             materials.Checked = this.preferences.Materials;
             normals.Checked = this.preferences.Normals;
             textures.Checked = this.preferences.Textures;
@@ -49,7 +48,6 @@ namespace CesiumIonRevitAddin.Forms
 
             this.preferences.SharedCoordinates = sharedCoordinates.Checked;
             this.preferences.TrueNorth = sharedCoordinates.Checked; // For now, true north only be used with shared coordinates
-            this.preferences.Instancing = instancing.Checked;
             this.preferences.EpsgCode = crsInput.Text;
             this.preferences.Materials = materials.Checked;
             this.preferences.Normals = normals.Checked;

--- a/CesiumIonRevitAddin/Preferences.cs
+++ b/CesiumIonRevitAddin/Preferences.cs
@@ -15,7 +15,7 @@ namespace CesiumIonRevitAddin
         public bool Properties { get; set; }
         public bool RelocateTo0 { get; set; }
         public bool FlipAxis { get; set; } = true;
-        public bool Instancing { get; set; } = false;
+        public bool SymbolicInstancing { get; set; } = true;
         public bool TrueNorth { get; set; } = true;
         public bool SharedCoordinates { get; set; } = true;
         public string EpsgCode { get; set; } = "";

--- a/CesiumIonRevitAddin/Utils/GLTFExportUtils.cs
+++ b/CesiumIonRevitAddin/Utils/GLTFExportUtils.cs
@@ -23,7 +23,7 @@ namespace CesiumIonRevitAddin.Utils
 
             return m ?? GltfExportUtils.CreateGltfMaterial(DEF_MATERIAL_NAME, 0, new Color(DEF_COLOR, DEF_COLOR, DEF_COLOR), doubleSided);
         }
-        public static GltfBinaryData AddGeometryMeta(
+        public static GltfBinaryData AddGeometryBinaryData(
             List<GltfBuffer> buffers,
             List<GltfAccessor> accessors,
             List<GltfBufferView> bufferViews,

--- a/CesiumIonRevitAddin/gltf/GltfExportContext.cs
+++ b/CesiumIonRevitAddin/gltf/GltfExportContext.cs
@@ -733,18 +733,7 @@ namespace CesiumIonRevitAddin.Gltf
                 return;
             }
 
-            GltfNode currentNode = nodes.CurrentItem;
-            // TODO: skip identity matrix and !null
-            Autodesk.Revit.DB.Transform currentMatrix = null;
-            if (isChild)
-            {
-                currentMatrix = parentTransformInverse * currentElementTransform;
-            }
-            else
-            {
-                currentMatrix = transformStack.Peek();
-            }
-            currentNode.Matrix = TransformToList(currentMatrix);
+            AddCurrentTransformToNode(nodes.CurrentItem);
 
             foreach (Mesh mesh in rpcMeshes)
             {
@@ -866,25 +855,8 @@ namespace CesiumIonRevitAddin.Gltf
 
         void AddCurrentTransformToNode(GltfNode gltfNode)
         {
-            // TODO: skip identity matrix and !null
-            Autodesk.Revit.DB.Transform currentMatrix = null;
-            if (isChild)
-            {
-                currentMatrix = parentTransformInverse * currentElementTransform; // currentElementTransform same as transformStack?
-            }
-            else
-            {
-                currentMatrix = transformStack.Peek();
-            }
-
-            if (currentMatrix.IsIdentity)
-            {
-                gltfNode.Matrix = null;
-            }
-            else
-            {
-                gltfNode.Matrix = TransformToList(currentMatrix);
-            }
+            Autodesk.Revit.DB.Transform currentMatrix = isChild ? parentTransformInverse * currentElementTransform : transformStack.Peek();
+            gltfNode.Matrix = currentMatrix.IsIdentity ? null : TransformToList(currentMatrix);
         }
 
         public void OnPolymesh(PolymeshTopology polymeshTopology)
@@ -912,8 +884,7 @@ namespace CesiumIonRevitAddin.Gltf
 
             if (preferences.Normals)
             {
-                // TODO: what transform should normals have? Probably identity.
-                GltfExportUtils.AddNormals(transformStack.Peek(), polymeshTopology, currentGeometry.CurrentItem.Normals);
+                GltfExportUtils.AddNormals(Autodesk.Revit.DB.Transform.Identity, polymeshTopology, currentGeometry.CurrentItem.Normals);
             }
 
             if (materialHasTexture)

--- a/CesiumIonRevitAddin/gltf/GltfExportContext.cs
+++ b/CesiumIonRevitAddin/gltf/GltfExportContext.cs
@@ -2,14 +2,11 @@
 using CesiumIonRevitAddin.Export;
 using CesiumIonRevitAddin.Model;
 using CesiumIonRevitAddin.Utils;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Security.Cryptography;
-using System.Text;
 using System.Windows.Media.Media3D;
 
 namespace CesiumIonRevitAddin.Gltf
@@ -24,12 +21,7 @@ namespace CesiumIonRevitAddin.Gltf
         private Autodesk.Revit.DB.Element element;
         private readonly List<Document> documents = new List<Document>();
         private bool cancelation;
-        // We record instanceStackDepth separately from getting it via transformStack.Count because there are
-        // cases where OnInstanceBegin is immediately followed by OnInstanceEnd, then OnPolymesh is triggered.
-        // We detect and handle this case.
-        private int instanceStackDepth = 0;
         private readonly Stack<Autodesk.Revit.DB.Transform> transformStack = new Stack<Autodesk.Revit.DB.Transform>();
-        private readonly Stack<Autodesk.Revit.DB.Transform> rawTransformStack = new Stack<Autodesk.Revit.DB.Transform>();
         private GltfNode xFormNode;
         private readonly List<GltfAccessor> accessors = new List<GltfAccessor>();
         private readonly List<GltfBufferView> bufferViews = new List<GltfBufferView>();
@@ -46,14 +38,15 @@ namespace CesiumIonRevitAddin.Gltf
         private List<string> extensionsRequired = null;
         private readonly Dictionary<string, GltfExtensionSchema> extensions = new Dictionary<string, GltfExtensionSchema>();
         private readonly GltfExtStructuralMetadataExtensionSchema extStructuralMetadataExtensionSchema = new GltfExtStructuralMetadataExtensionSchema();
-        private Autodesk.Revit.DB.Transform cachedTransform;
         private bool khrTextureTransformAdded;
-        private bool skipElementFlag;
+        private bool shouldSkipElement;
         private Autodesk.Revit.DB.Transform linkTransformation;
         private IndexedDictionary<GeometryDataObject> currentGeometry;
         private IndexedDictionary<VertexLookupIntObject> currentVertices;
-        private readonly Dictionary<string, int> geometryDataObjectIndices = new Dictionary<string, int>();
         private bool materialHasTexture;
+#if !REVIT2019 && !REVIT2020 && !REVIT2021 && !REVIT2022
+        private readonly Dictionary<string, int> symbolGeometryIdToGltfNode = new Dictionary<string, int>();
+#endif
 
         public GltfExportContext(Document doc, Preferences preferences)
         {
@@ -93,9 +86,19 @@ namespace CesiumIonRevitAddin.Gltf
             return specTypeIds.Contains(forgeTypeId);
         }
 #endif
+        readonly System.Diagnostics.Stopwatch stopwatch = new System.Diagnostics.Stopwatch();
 
         public bool Start()
         {
+            stopwatch.Start();
+
+            // Always set to true until Revit 2022 is phased out.
+            preferences.SymbolicInstancing = true;
+#if REVIT2019 || REVIT2020 || REVIT2021 || REVIT2022
+            // Disable instancing for Revit 2022 and earlier, since it does not support GeometrySymbolId.
+            preferences.SymbolicInstancing = false;
+#endif
+
             Logger.Enabled = verboseLog;
             cancelation = false;
 
@@ -103,7 +106,7 @@ namespace CesiumIonRevitAddin.Gltf
 
             Reset();
 
-            // Create the glTF temp export directory
+            // Create the glTF temp export directory.
             if (!Directory.Exists(preferences.TempDirectory))
             {
                 Directory.CreateDirectory(preferences.TempDirectory);
@@ -113,7 +116,7 @@ namespace CesiumIonRevitAddin.Gltf
 
             transformStack.Push(Autodesk.Revit.DB.Transform.Identity);
 
-            // Holds metadata along with georeference transforms
+            // Holds metadata along with georeference transforms.
             var rootNode = new GltfNode
             {
                 Name = "rootNode"
@@ -297,6 +300,10 @@ namespace CesiumIonRevitAddin.Gltf
             FileExport.Run(preferences, bufferViews, buffers, binaryFileData,
                 scenes, nodes, meshes, materials, accessors, extensionsUsed, extensionsRequired, extensions, new GltfVersion(), images, textures, samplers);
             Logger.Instance.Log("Completed model export.");
+            stopwatch.Stop();
+            TimeSpan timeSpan = stopwatch.Elapsed;
+            string elapsedTime = String.Format("{0:00}:{1:00}:{2:00}.{3:00}", timeSpan.Hours, timeSpan.Minutes, timeSpan.Seconds, timeSpan.Milliseconds / 10);
+            Logger.Instance.Log("Elapsed time: " + elapsedTime);
 
             // Write out the json for the tiler
             TilerExportUtils.WriteTilerJson(preferences);
@@ -307,47 +314,88 @@ namespace CesiumIonRevitAddin.Gltf
             return cancelation;
         }
 
-        // Most instanced elements have this event stack order: OnElementBegin->OnInstanceBegin->(geometry/material events)->OnInstanceEnd->OnElementEnd
-        // But some do this: OnElementBegin->OnInstanceBegin->->OnInstanceEnd->(geometry/material events)->OnElementEnd
-        // This records if the latter has happened
-        private bool onInstanceEndCompleted = false;
-        private bool useCurrentInstanceTransform = false;
         private bool shouldLogOnElementEnd = false;
+
+        string symbolGeometryUniqueId = "";
+        int instanceIndex = -1;
+        bool isChild = false;
+        Autodesk.Revit.DB.Transform currentElementTransform = null;
         public RenderNodeAction OnElementBegin(ElementId elementId)
         {
-            onInstanceEndCompleted = false;
-            useCurrentInstanceTransform = false;
             parentTransformInverse = null;
             shouldLogOnElementEnd = false;
+            symbolGeometryUniqueId = "";
+            instanceIndex = -1;
 
             element = Doc.GetElement(elementId);
 
-            if (!Util.CanBeLockOrHidden(element, view) ||
-                (element is Level))
+            if (!Util.CanBeLockOrHidden(element, view) || (element is Level))
             {
-                skipElementFlag = true;
+                shouldSkipElement = true;
                 return RenderNodeAction.Skip;
             }
 
             if (nodes.Contains(element.UniqueId))
             {
                 // Duplicate element, skip adding.
-                skipElementFlag = true;
+                shouldSkipElement = true;
                 return RenderNodeAction.Skip;
             }
 
-            if (element is RevitLinkInstance linkInstance)
-            {
-                linkTransformation = linkInstance.GetTransform();
-            }
+            linkTransformation = (element as RevitLinkInstance)?.GetTransform();
 
             Logger.Instance.Log("Processing element " + element.Name + ", ID: " + element.Id.ToString());
             shouldLogOnElementEnd = true;
 
             var newNode = new GltfNode();
+            nodes.AddOrUpdateCurrent(element.UniqueId, newNode);
             string categoryName = element.Category != null ? element.Category.Name : "Undefined";
             string familyName = GetFamilyName(element);
             newNode.Name = Util.CreateClassName(categoryName, familyName) + ": " + GetTypeNameIfApplicable(elementId);
+
+            // Reset currentGeometry for new element
+            if (currentGeometry == null)
+            {
+                currentGeometry = new IndexedDictionary<GeometryDataObject>();
+            }
+            else
+            {
+                currentGeometry.Reset();
+            }
+
+            if (currentVertices == null)
+            {
+                currentVertices = new IndexedDictionary<VertexLookupIntObject>();
+            }
+            else
+            {
+                currentVertices.Reset();
+            }
+
+#if !REVIT2019 &&!REVIT2020 && !REVIT2021 && !REVIT2022
+            if (preferences.SymbolicInstancing)
+            {
+                Options options = new Options();
+                GeometryElement geometryElement = element.get_Geometry(options);
+                if (geometryElement != null)
+                {
+                    foreach (GeometryObject geometryObject in geometryElement)
+                    {
+                        if (geometryObject is GeometryInstance geometryInstance)
+                        {
+                            SymbolGeometryId symbolGeometryId = geometryInstance.GetSymbolGeometryId();
+                            symbolGeometryUniqueId = symbolGeometryId.AsUniqueIdentifier();
+                            if (symbolGeometryIdToGltfNode.TryGetValue(symbolGeometryUniqueId, out int index))
+                            {
+                                nodes.CurrentItem.Mesh = index;
+                                instanceIndex = index;
+                                break; // Currently only handling the first GeometryInstance
+                            }
+                        }
+                    }
+                }
+            }
+#endif
 
             var classMetadata = new Dictionary<string, object>();
             if (preferences.ExportMetadata)
@@ -425,24 +473,26 @@ namespace CesiumIonRevitAddin.Gltf
 #if REVIT2022 || REVIT2023
                 int elementIdValue = elementId.IntegerValue;
 #else
-                int elementIdValue = (int) elementId.Value;
+                int elementIdValue = (int)elementId.Value;
 #endif
                 newNode.Extensions.EXT_structural_metadata.AddProperty("elementId", elementIdValue);
                 extStructuralMetadataExtensionSchema.AddSchemaProperty(categoryName, familyName, "elementId", elementIdValue.GetType());
             }
 
-            nodes.AddOrUpdateCurrent(element.UniqueId, newNode);
-
-            // set parent to Supercomponent if it exists.
+            // Set parent to Supercomponent if it exists.
             if (element is FamilyInstance familyInstance && familyInstance.SuperComponent != null)
             {
+                isChild = true;
+                currentElementTransform = familyInstance.GetTransform();
                 Element superComponent = familyInstance.SuperComponent;
+                var parentInstance = (Instance)superComponent;
                 // It can be possible for an Element's Supercomponent to not be in a View.
                 // For example, if you isolate only the "Planting" category in Snowdon,
                 // some Elements have a Supercomponent from the "Site" class that will be missing.
                 if (!nodes.Contains(superComponent.UniqueId))
                 {
                     xFormNode.Children.Add(nodes.CurrentIndex);
+                    parentTransformInverse = Autodesk.Revit.DB.Transform.Identity;
                 }
                 else
                 {
@@ -455,34 +505,13 @@ namespace CesiumIonRevitAddin.Gltf
                     GltfNode parentNode = nodes.GetElement(superComponent.UniqueId);
                     parentNode.Children = parentNode.Children ?? new List<int>();
                     parentNode.Children.Add(nodes.CurrentIndex);
-                    useCurrentInstanceTransform = true;
-
-                    var parentInstance = (Instance)superComponent;
                     parentTransformInverse = parentInstance.GetTransform().Inverse;
                 }
             }
             else
             {
+                isChild = false;
                 xFormNode.Children.Add(nodes.CurrentIndex);
-            }
-
-            // Reset currentGeometry for new element
-            if (currentGeometry == null)
-            {
-                currentGeometry = new IndexedDictionary<GeometryDataObject>();
-            }
-            else
-            {
-                currentGeometry.Reset();
-            }
-
-            if (currentVertices == null)
-            {
-                currentVertices = new IndexedDictionary<VertexLookupIntObject>();
-            }
-            else
-            {
-                currentVertices.Reset();
             }
 
             return RenderNodeAction.Proceed;
@@ -490,15 +519,22 @@ namespace CesiumIonRevitAddin.Gltf
 
         public void OnElementEnd(ElementId elementId)
         {
-            if (skipElementFlag ||
-                currentVertices == null ||
-                currentVertices.List.Count == 0 ||
-                !Util.CanBeLockOrHidden(element, view))
+
+            // Skip writing out nodes for links.
+            if (linkElementIsEnding)
             {
-                skipElementFlag = false;
+                linkElementIsEnding = false;
+                return;
+            }
+
+            bool verticesAreBad = currentVertices == null || currentVertices.List.Count == 0;
+            if (instanceIndex != -1) verticesAreBad = false; // Vertices check is invalid if this is a GPU instance.
+            if (shouldSkipElement || verticesAreBad || !Util.CanBeLockOrHidden(element, view))
+            {
+                shouldSkipElement = false;
                 if (shouldLogOnElementEnd)
                 {
-                    Logger.Instance.Log("...Finished Processing element " + element.Name);
+                    Logger.Instance.Log($"...Finished Processing element {element.Name}, {element.Id}");
                 }
                 return;
             }
@@ -509,47 +545,26 @@ namespace CesiumIonRevitAddin.Gltf
                 Primitives = new List<GltfMeshPrimitive>()
             };
 
-            int instanceIndex = -1;
-            string geometryDataObjectHash = "";
-            var collectionToHash = new Dictionary<string, GeometryDataObject>(); // contains data that will be common across instances
-
-            foreach (KeyValuePair<string, VertexLookupIntObject> kvp in currentVertices.Dict)
-            {
-                GeometryDataObject geometryDataObject = currentGeometry.GetElement(kvp.Key);
-                var vertices = geometryDataObject.Vertices;
-                foreach (KeyValuePair<PointIntObject, int> p in kvp.Value)
-                {
-                    vertices.Add(p.Key.X);
-                    vertices.Add(p.Key.Y);
-                    vertices.Add(p.Key.Z);
-                }
-
-                // also add materials to the hash to test for instancing since in glTF mesh primitives are tied to a material
-                if (preferences.Instancing)
-                {
-                    var materialKey = kvp.Key.Split('_')[1];
-                    collectionToHash.Add(materialKey, geometryDataObject);
-                }
-            }
-
-            if (preferences.Instancing)
-            {
-                geometryDataObjectHash = ComputeHash(collectionToHash);
-                if (geometryDataObjectIndices.TryGetValue(geometryDataObjectHash, out var index))
-                {
-                    nodes.CurrentItem.Mesh = index;
-                    instanceIndex = index;
-                }
-            }
-
             if (instanceIndex == -1)
             {
+                foreach (KeyValuePair<string, VertexLookupIntObject> kvp in currentVertices.Dict)
+                {
+                    GeometryDataObject geometryDataObject = currentGeometry.GetElement(kvp.Key);
+                    List<double> vertices = geometryDataObject.Vertices;
+                    foreach (KeyValuePair<PointIntObject, int> p in kvp.Value)
+                    {
+                        vertices.Add(p.Key.X);
+                        vertices.Add(p.Key.Y);
+                        vertices.Add(p.Key.Z);
+                    }
+                }
+
                 // add all mesh primitives
                 foreach (KeyValuePair<string, GeometryDataObject> kvp in currentGeometry.Dict)
                 {
-                    var name = kvp.Key;
-                    var geometryDataObject = kvp.Value;
-                    GltfBinaryData elementBinaryData = GltfExportUtils.AddGeometryMeta(
+                    string name = kvp.Key;
+                    GeometryDataObject geometryDataObject = kvp.Value;
+                    GltfBinaryData elementBinaryData = GltfExportUtils.AddGeometryBinaryData(
                          buffers,
                          accessors,
                          bufferViews,
@@ -590,23 +605,35 @@ namespace CesiumIonRevitAddin.Gltf
                 meshes.AddOrUpdateCurrent(element.UniqueId, newMesh);
                 nodes.CurrentItem.Mesh = meshes.CurrentIndex;
                 meshes.CurrentItem.Name = newMesh.Name;
-                if (preferences.Instancing)
+
+#if !REVIT2019 &&!REVIT2020 && !REVIT2021 && !REVIT2022
+                if (IsFirstInstanceableElement)
                 {
-                    geometryDataObjectIndices.Add(geometryDataObjectHash, meshes.CurrentIndex);
+                    if (symbolGeometryIdToGltfNode.TryGetValue(symbolGeometryUniqueId, out _))
+                    {
+#if DEBUG
+                        System.Diagnostics.Debug.Assert(false, "The key already exists in the dictionary.");
+#endif
+                    }
+                    else
+                    {
+                        symbolGeometryIdToGltfNode.Add(symbolGeometryUniqueId, meshes.CurrentIndex);
+                    }
                 }
+#endif
+            }
+            else
+            {
+                nodes.CurrentItem.Mesh = instanceIndex;
             }
 
             element = Doc.GetElement(elementId);
-            Logger.Instance.Log("...Finished Processing element " + element.Name);
+            Logger.Instance.Log($"...Finished Processing element {element.Name}, {element.Id}");
         }
 
         public RenderNodeAction OnInstanceBegin(InstanceNode node)
         {
-            this.instanceStackDepth++;
-
-            var transformationMultiply = CurrentFullTransform.Multiply(node.GetTransform());
-            transformStack.Push(transformationMultiply);
-            rawTransformStack.Push(node.GetTransform());
+            transformStack.Push(transformStack.Peek().Multiply(node.GetTransform()));
 
             return RenderNodeAction.Proceed;
         }
@@ -618,6 +645,8 @@ namespace CesiumIonRevitAddin.Gltf
 #pragma warning restore IDE0051 // Remove unused private members
 #pragma warning restore S1144 // Unused private types or members should be removed
         {
+            if (transform == null) return "";
+
             var x = transform.BasisX;
             var y = transform.BasisY;
             var z = transform.BasisZ;
@@ -626,53 +655,16 @@ namespace CesiumIonRevitAddin.Gltf
             string transformDetails = $"BasisX: ({x.X}, {x.Y}, {x.Z})\n" +
                                       $"BasisY: ({y.X}, {y.Y}, {y.Z})\n" +
                                       $"BasisZ: ({z.X}, {z.Y}, {z.Z})\n" +
-                                      $"Origin: ({origin.X}, {origin.Y}, {origin.Z})\n";
+                                      $"Origin: ({origin.X}, {origin.Y}, {origin.Z})";
 
             return transformDetails;
         }
 
         public void OnInstanceEnd(InstanceNode node)
         {
-            instanceStackDepth--;
-
             // Note: This method is invoked even for instances that were skipped.
 
-            Autodesk.Revit.DB.Transform transform = transformStack.Pop();
-            rawTransformStack.Pop();
-
-            if (!preferences.Instancing)
-            {
-                return;
-            }
-
-            // Do not write to the node if there is an instance stack.
-            // This happens with railings because the balusters are sub-instances of the railing instance.
-            if (instanceStackDepth > 0)
-            {
-                return;
-            }
-
-            if (!transform.IsIdentity)
-            {
-                GltfNode currentNode = nodes.CurrentItem;
-
-                var currentNodeTransform = node.GetTransform();
-                if (useCurrentInstanceTransform) // for nodes with a non-root parent
-                {
-                    if (!currentNodeTransform.IsIdentity)
-                    {
-                        Autodesk.Revit.DB.Transform outgoingMatrix = parentTransformInverse * currentNodeTransform;
-                        currentNode.Matrix = TransformToList(outgoingMatrix);
-                    }
-                }
-                else
-                {
-                    currentNode.Matrix = TransformToList(transform);
-                }
-            }
-
-            cachedTransform = transform;
-            onInstanceEndCompleted = true;
+            transformStack.Pop();
         }
 
         private static List<double> TransformToList(Autodesk.Revit.DB.Transform transform)
@@ -688,28 +680,37 @@ namespace CesiumIonRevitAddin.Gltf
 
         public RenderNodeAction OnLinkBegin(LinkNode node)
         {
+            if (preferences.VerboseLogging) Logger.Instance.Log("Beginning OnLinkBegin...");
             if (!preferences.Links)
             {
                 return RenderNodeAction.Skip;
             }
 
             documents.Add(node.GetDocument());
-            transformStack.Push(CurrentFullTransform.Multiply(linkTransformation));
+            transformStack.Push(transformStack.Peek().Multiply(linkTransformation));
 
+            if (preferences.VerboseLogging) Logger.Instance.Log("...OnLinkBegin");
             return RenderNodeAction.Proceed;
         }
 
+        bool linkElementIsEnding = false;
         public void OnLinkEnd(LinkNode node)
         {
+            // Note: This method is invoked even for instances that were skipped.
+
+            if (preferences.VerboseLogging) Logger.Instance.Log("Beginning OnLinkEnd...");
             if (!preferences.Links)
             {
                 return;
             }
 
-            // Note: This method is invoked even for instances that were skipped.
             transformStack.Pop();
 
             documents.RemoveAt(1); // remove the item added in OnLinkBegin
+
+            if (preferences.VerboseLogging) Logger.Instance.Log("...OnLinkEnd");
+
+            linkElementIsEnding = true;
         }
 
         public RenderNodeAction OnFaceBegin(FaceNode node)
@@ -720,7 +721,7 @@ namespace CesiumIonRevitAddin.Gltf
 
         public void OnFaceEnd(FaceNode node)
         {
-            // no-op: This custom exporter is not set to export faces.
+            // no-op: This exporter is not set to export faces.
         }
 
         public void OnRPC(RPCNode node)
@@ -731,6 +732,19 @@ namespace CesiumIonRevitAddin.Gltf
             {
                 return;
             }
+
+            GltfNode currentNode = nodes.CurrentItem;
+            // TODO: skip identity matrix and !null
+            Autodesk.Revit.DB.Transform currentMatrix = null;
+            if (isChild)
+            {
+                currentMatrix = parentTransformInverse * currentElementTransform;
+            }
+            else
+            {
+                currentMatrix = transformStack.Peek();
+            }
+            currentNode.Matrix = TransformToList(currentMatrix);
 
             foreach (Mesh mesh in rpcMeshes)
             {
@@ -844,44 +858,48 @@ namespace CesiumIonRevitAddin.Gltf
             }
         }
 
-        public void OnPolymesh(PolymeshTopology polymeshTopology)
+        // Return if the currently parsed element is potentially GPU-instancable, but has not been recorded as such yet.
+        private bool IsFirstInstanceableElement
         {
-            if (preferences.VerboseLogging) Logger.Instance.Log("Beginning OnPolymesh...");
-            GltfExportUtils.AddOrUpdateCurrentItem(nodes, currentGeometry, currentVertices, materials);
+            get { return instanceIndex == -1 && symbolGeometryUniqueId != ""; }
+        }
 
-            var pts = polymeshTopology.GetPoints();
-            if (!preferences.Instancing)
+        void AddCurrentTransformToNode(GltfNode gltfNode)
+        {
+            // TODO: skip identity matrix and !null
+            Autodesk.Revit.DB.Transform currentMatrix = null;
+            if (isChild)
             {
-                pts = pts.Select(p => CurrentFullTransform.OfPoint(p)).ToList();
+                currentMatrix = parentTransformInverse * currentElementTransform; // currentElementTransform same as transformStack?
             }
             else
             {
-                // handle the case of where OnInstanceBegin and OnInstanceEnd occur with no events in between
-                // i.e.: OnElementBegin->OnInstanceBegin->OnInstanceEnd->OnPolymesh
-                if (onInstanceEndCompleted && instanceStackDepth == 0)
-                {
-                    Autodesk.Revit.DB.Transform inverse = cachedTransform.Inverse;
-                    pts = pts.Select(p => inverse.OfPoint(p)).ToList();
-                }
-                // Transform stacks above 1 indicate a nested instance.
-                // This could be either from a nested instance in a single document. This has happened with part of a chair being an instance inside a chair instance.
-                // It would also be via a linked Revit document with its own transform stack.
-                // We need to multiply by everything except the transform deepest on the stack.
-                else if (rawTransformStack.Count == 2)
-                {
-                    pts = pts.Select(p => rawTransformStack.Peek().OfPoint(p)).ToList();
-                }
-                // Convert to a List so we can non-destructively multiply by everything except the base stack item.
-                else if (rawTransformStack.Count > 2)
-                {
-                    var rawTransformArray = rawTransformStack.ToArray();
-                    for (int i = 1; i < rawTransformArray.Length; i++)
-                    {
-                        pts = pts.Select(p => rawTransformArray[i].OfPoint(p)).ToList();
-                    }
-                }
+                currentMatrix = transformStack.Peek();
             }
 
+            if (currentMatrix.IsIdentity)
+            {
+                gltfNode.Matrix = null;
+            }
+            else
+            {
+                gltfNode.Matrix = TransformToList(currentMatrix);
+            }
+        }
+
+        public void OnPolymesh(PolymeshTopology polymeshTopology)
+        {
+            GltfExportUtils.AddOrUpdateCurrentItem(nodes, currentGeometry, currentVertices, materials);
+
+            AddCurrentTransformToNode(nodes.CurrentItem);
+
+            if (instanceIndex != -1)
+            {
+                if (preferences.VerboseLogging) Logger.Instance.Log("...GPU instance found, skipping OnPolymesh)");
+                return;
+            }
+
+            var pts = polymeshTopology.GetPoints();
             foreach (PolymeshFacet facet in polymeshTopology.GetFacets())
             {
                 foreach (var vertIndex in facet.GetVertices())
@@ -894,15 +912,14 @@ namespace CesiumIonRevitAddin.Gltf
 
             if (preferences.Normals)
             {
-                GltfExportUtils.AddNormals(CurrentFullTransform, polymeshTopology, currentGeometry.CurrentItem.Normals);
+                // TODO: what transform should normals have? Probably identity.
+                GltfExportUtils.AddNormals(transformStack.Peek(), polymeshTopology, currentGeometry.CurrentItem.Normals);
             }
 
             if (materialHasTexture)
             {
                 GltfExportUtils.AddTexCoords(polymeshTopology, currentGeometry.CurrentItem.TexCoords);
             }
-
-            if (preferences.VerboseLogging) Logger.Instance.Log("...ending OnPolymesh");
         }
 
         RenderNodeAction IExportContext.OnViewBegin(ViewNode node)
@@ -956,38 +973,6 @@ namespace CesiumIonRevitAddin.Gltf
             else
             {
                 return "Type not applicable or not found";
-            }
-        }
-
-        private Autodesk.Revit.DB.Transform CurrentFullTransform
-        {
-            get
-            {
-                return transformStack.Peek();
-            }
-        }
-
-        public static string ComputeHash(Dictionary<string, GeometryDataObject> collectionToHash)
-        {
-            var settings = new JsonSerializerSettings
-            {
-                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                Formatting = Formatting.None,
-                NullValueHandling = NullValueHandling.Ignore
-            };
-            string json = JsonConvert.SerializeObject(collectionToHash, settings);
-
-            using (SHA256 sha256Hash = SHA256.Create())
-            {
-                byte[] data = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(json));
-
-                // Convert the byte array to a hexadecimal string
-                StringBuilder sBuilder = new StringBuilder();
-                for (int i = 0; i < data.Length; i++)
-                {
-                    sBuilder.Append(data[i].ToString("x2"));
-                }
-                return sBuilder.ToString();
             }
         }
     }

--- a/CesiumIonRevitAddin/gltf/GltfExportContext.cs
+++ b/CesiumIonRevitAddin/gltf/GltfExportContext.cs
@@ -887,8 +887,14 @@ namespace CesiumIonRevitAddin.Gltf
                 return;
             }
 
+            Autodesk.Revit.DB.Transform normalsTransform = Autodesk.Revit.DB.Transform.Identity;
+
             var pts = polymeshTopology.GetPoints();
-            if (!isFamilyInstance) for (int i = 0; i < pts.Count; i++) pts[i] = transformStack.Peek().OfPoint(pts[i]);
+            if (!isFamilyInstance)
+            {
+                for (int i = 0; i < pts.Count; i++) pts[i] = transformStack.Peek().OfPoint(pts[i]);
+                normalsTransform = transformStack.Peek();
+            }
 
             foreach (PolymeshFacet facet in polymeshTopology.GetFacets())
             {
@@ -902,7 +908,7 @@ namespace CesiumIonRevitAddin.Gltf
 
             if (preferences.Normals)
             {
-                GltfExportUtils.AddNormals(Autodesk.Revit.DB.Transform.Identity, polymeshTopology, currentGeometry.CurrentItem.Normals);
+                GltfExportUtils.AddNormals(normalsTransform, polymeshTopology, currentGeometry.CurrentItem.Normals);
             }
 
             if (materialHasTexture)


### PR DESCRIPTION
This PR leverages Revit 2023+'s ability to detect instances via `SymbolGeometryId` to improve export performance.

The "GPU Instancing" UI option has been removed. Since it improves export time, memory usage, etc., it will be automatically enabled by default for Revit 2023+.

An "Elapsed Time" line to the final line of the output log file was also added.

Several minor changes ranging from stylistic consistency to cosmetics were added.

Will make https://github.com/CesiumGS/cesium-ion-revit-add-in/issues/31 obsolete.