### PR TITLE
Additional texture schema and file-path support

### DIFF
--- a/CesiumIonRevitAddin/CesiumIonRevitAddin.projitems
+++ b/CesiumIonRevitAddin/CesiumIonRevitAddin.projitems
@@ -74,6 +74,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Forms\ExportDialog.resx">
       <DependentUpon>ExportDialog.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Forms\IonConnectDialog.resx">
       <DependentUpon>IonConnectDialog.cs</DependentUpon>

--- a/CesiumIonRevitAddin/CesiumIonRevitAddin.projitems
+++ b/CesiumIonRevitAddin/CesiumIonRevitAddin.projitems
@@ -74,7 +74,6 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Forms\ExportDialog.resx">
       <DependentUpon>ExportDialog.cs</DependentUpon>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Forms\IonConnectDialog.resx">
       <DependentUpon>IonConnectDialog.cs</DependentUpon>

--- a/CesiumIonRevitAddin/Export/RevitMaterials.cs
+++ b/CesiumIonRevitAddin/Export/RevitMaterials.cs
@@ -398,15 +398,12 @@ namespace CesiumIonRevitAddin.Export
 
             string programFilesPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
             string programFilesX86Path = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
-
             List<string> possibleBasePaths = new List<string>();
-
             foreach (string possiblePathExtension in possiblePathExtensions)
             {
                 possibleBasePaths.Add(System.IO.Path.Combine(programFilesX86Path, possiblePathExtension));
                 possibleBasePaths.Add(System.IO.Path.Combine(programFilesPath, possiblePathExtension));
             }
-
             possibleBasePaths.AddRange(GetAdditionalRenderAppearancePaths());
 
             foreach (string basePath in possibleBasePaths)

--- a/CesiumIonRevitAddin/Export/RevitMaterials.cs
+++ b/CesiumIonRevitAddin/Export/RevitMaterials.cs
@@ -321,7 +321,11 @@ namespace CesiumIonRevitAddin.Export
             }
 
             var connectedProperty = baseColorProperty.GetConnectedProperty(0) as Asset;
+
             AssetPropertyString path = connectedProperty.FindByName(UnifiedBitmap.UnifiedbitmapBitmap) as AssetPropertyString;
+            // Procedurally generated textures (e.g., NoiseSchema) will not have bitmaps.
+            if (path == null) return bitmapInfoCollection;
+
             var absolutePath = GetAbsoluteMaterialPath(path.Value);
             // It's possible for a bitmap object propery to have a path to a texture file, but that
             // file is not on the disk. The can happen if the texture patch and the model is being exported

--- a/CesiumIonRevitAddin/Export/RevitMaterials.cs
+++ b/CesiumIonRevitAddin/Export/RevitMaterials.cs
@@ -285,10 +285,13 @@ namespace CesiumIonRevitAddin.Export
                 {
                     case "PrismOpaqueSchema":
                     case "AdvancedOpaque":
-                        attachedBitmapInfo = ParseSchemaPrismOpaqueSchema(renderingAsset);
+                        attachedBitmapInfo = ParsePrismOpaqueSchema(renderingAsset);
                         break;
                     case "HardwoodSchema":
-                        attachedBitmapInfo = ParseSchemaHardwoodSchema(renderingAsset);
+                        attachedBitmapInfo = ParseHardwoodSchema(renderingAsset);
+                        break;
+                    case "GenericSchema":
+                        attachedBitmapInfo = ParseGenericSchema(renderingAsset);
                         break;
                     default:
                         Logger.Instance.Log("skipping material processing of unknown material schema type: " + schema);
@@ -300,11 +303,17 @@ namespace CesiumIonRevitAddin.Export
         }
 
         // https://help.autodesk.com/view/RVT/2022/ENU/?guid=Revit_API_Revit_API_Developers_Guide_Revit_Geometric_Elements_Material_Material_Schema_Prism_Schema_Opaque_html
-        private static List<BitmapInfo> ParseSchemaPrismOpaqueSchema(Asset renderingAsset)
+        private static List<BitmapInfo> ParsePrismOpaqueSchema(Asset renderingAsset)
+        {
+            AssetProperty baseColorProperty = renderingAsset.FindByName(AdvancedOpaque.OpaqueAlbedo);
+            List<BitmapInfo> bitmapInfoCollection = GetBitmapInfoCollection(baseColorProperty);
+            return bitmapInfoCollection;
+        }
+
+        private static List<BitmapInfo> GetBitmapInfoCollection(AssetProperty baseColorProperty)
         {
             var bitmapInfoCollection = new List<BitmapInfo>();
 
-            AssetProperty baseColorProperty = renderingAsset.FindByName(AdvancedOpaque.OpaqueAlbedo);
             if (baseColorProperty.NumberOfConnectedProperties < 1)
             {
                 return bitmapInfoCollection;
@@ -330,38 +339,22 @@ namespace CesiumIonRevitAddin.Export
             return bitmapInfoCollection;
         }
 
-        // https://help.autodesk.com/view/RVT/2025/ENU/?guid=Revit_API_Revit_API_Developers_Guide_Revit_Geometric_Elements_Material_Material_Schema_Protein_Hardwood_Schema_html
-        private static List<BitmapInfo> ParseSchemaHardwoodSchema(Asset renderingAsset)
+        private static List<BitmapInfo> ParseGenericSchema(Asset renderingAsset)
         {
-            var bitmapInfoCollection = new List<BitmapInfo>();
-
-            AssetProperty baseColorProperty = renderingAsset.FindByName(Hardwood.HardwoodColor);
-            if (baseColorProperty.NumberOfConnectedProperties < 1)
-            {
-                return bitmapInfoCollection;
-            }
-
-            var connectedProperty = baseColorProperty.GetConnectedProperty(0) as Asset;
-            var path = connectedProperty.FindByName(UnifiedBitmap.UnifiedbitmapBitmap) as AssetPropertyString;
-            string absolutePath = GetAbsoluteMaterialPath(path.Value);
-            // It's possible for a bitmap object propery to have a path to a texture file, but that
-            // file is not on the disk. The can happen if the texture patch and the model is being exported
-            // on another machine that doesn't have the materials installed in that location. Test for this case.
-            if (absolutePath == null)
-            {
-                Logger.Instance.Log("Could not find the following texture: " + path.Value);
-                return bitmapInfoCollection;
-            }
-            var baseColor = new BitmapInfo(absolutePath, GltfBitmapType.baseColorTexture);
-
-            AddTextureTransformInfo(ref baseColor, connectedProperty);
-
-            bitmapInfoCollection.Add(baseColor);
-
+            AssetProperty baseColorProperty = renderingAsset.FindByName("generic_diffuse");
+            List<BitmapInfo> bitmapInfoCollection = GetBitmapInfoCollection(baseColorProperty);
             return bitmapInfoCollection;
         }
 
-        // https://help.autodesk.com/view/RVT/2025/ENU/?guid=Revit_API_Revit_API_Developers_Guide_Revit_Geometric_Elements_Material_Material_Schema_Other_Schema_UnifiedBitmap_html
+        // https://help.autodesk.com/view/RVT/2025/ENU/?guid=Revit_API_Revit_API_Developers_Guide_Revit_Geometric_Elements_Material_Material_Schema_Protein_Hardwood_Schema_html
+        private static List<BitmapInfo> ParseHardwoodSchema(Asset renderingAsset)
+        {
+            AssetProperty baseColorProperty = renderingAsset.FindByName(Hardwood.HardwoodColor);
+            List<BitmapInfo> bitmapInfoCollection = GetBitmapInfoCollection(baseColorProperty);
+            return bitmapInfoCollection;
+        }
+
+        // See https://help.autodesk.com/view/RVT/2025/ENU/?guid=Revit_API_Revit_API_Developers_Guide_Revit_Geometric_Elements_Material_Material_Schema_Other_Schema_UnifiedBitmap_html
         private static void AddTextureTransformInfo(ref BitmapInfo bitmapInfo, Asset connectedProperty)
         {
             bitmapInfo.Offset = new double[]
@@ -384,9 +377,18 @@ namespace CesiumIonRevitAddin.Export
             };
         }
 
+        private static readonly string baseCommonPath = Path.Combine("Common Files", "Autodesk Shared", "Materials", "Textures");
+        private static readonly string[] possiblePathExtensions = new string[] {
+            baseCommonPath,
+            Path.Combine(baseCommonPath, "1", "Mats"),
+            Path.Combine(baseCommonPath, "2", "Mats"),
+            Path.Combine(baseCommonPath, "3", "Mats")
+        };
+
         private static string GetAbsoluteMaterialPath(string relativeOrAbsolutePath)
         {
             string[] allPaths = relativeOrAbsolutePath.Split('|');
+            allPaths = allPaths.Distinct().ToArray();
             relativeOrAbsolutePath = allPaths[allPaths.Length - 1];
 
             if (Path.IsPathRooted(relativeOrAbsolutePath) && File.Exists(relativeOrAbsolutePath))
@@ -397,11 +399,13 @@ namespace CesiumIonRevitAddin.Export
             string programFilesPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
             string programFilesX86Path = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
 
-            List<string> possibleBasePaths = new List<string>
+            List<string> possibleBasePaths = new List<string>();
+
+            foreach (string possiblePathExtension in possiblePathExtensions)
             {
-                System.IO.Path.Combine(programFilesX86Path, "Common Files", "Autodesk Shared", "Materials", "Textures"),
-                System.IO.Path.Combine(programFilesPath, "Common Files", "Autodesk Shared", "Materials", "Textures")
-            };
+                possibleBasePaths.Add(System.IO.Path.Combine(programFilesX86Path, possiblePathExtension));
+                possibleBasePaths.Add(System.IO.Path.Combine(programFilesPath, possiblePathExtension));
+            }
 
             possibleBasePaths.AddRange(GetAdditionalRenderAppearancePaths());
 

--- a/CesiumIonRevitAddin/Export/RevitMaterials.cs
+++ b/CesiumIonRevitAddin/Export/RevitMaterials.cs
@@ -5,6 +5,7 @@ using CesiumIonRevitAddin.Utils;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace CesiumIonRevitAddin.Export
 {

--- a/CesiumIonRevitAddin/Model/VertexLookupIntObject.cs
+++ b/CesiumIonRevitAddin/Model/VertexLookupIntObject.cs
@@ -4,9 +4,19 @@ namespace CesiumIonRevitAddin.Model
 {
     internal class VertexLookupIntObject : Dictionary<PointIntObject, int>
     {
-        public int AddVertex(PointIntObject p) => this.ContainsKey(p)
-              ? this[p]
-              : this[p] = this.Count;
+        public int AddVertex(PointIntObject p)
+        {
+            if (this.ContainsKey(p))
+            {
+                return this[p];
+            }
+            else
+            {
+                int index = this.Count;
+                this[p] = index;
+                return index;
+            }
+        }
 
         /// <summary>
         /// Define equality for integer-based PointInt.

--- a/CesiumIonRevitAddin/Utils/GLTFExportUtils.cs
+++ b/CesiumIonRevitAddin/Utils/GLTFExportUtils.cs
@@ -10,6 +10,8 @@ namespace CesiumIonRevitAddin.Utils
     {
         private const int DEF_COLOR = 250;
         private const string DEF_MATERIAL_NAME = "default";
+        private const string BIN = ".bin";
+
         public static GltfMaterial GetGLTFMaterial(List<GltfMaterial> gltfMaterials, Material material, bool doubleSided)
         {
             // search for an already existing material
@@ -37,30 +39,27 @@ namespace CesiumIonRevitAddin.Utils
                 Uri = name + BIN
             };
             buffers.Add(buffer);
-            int bufferIdx = buffers.Count - 1;
+            int bufferIndex = buffers.Count - 1;
             GltfBinaryData bufferData = new GltfBinaryData
             {
                 Name = buffer.Uri
             };
 
-            byteOffset = GltfBinaryDataUtils.ExportVertices(bufferIdx, byteOffset, geometryDataObject, bufferData, bufferViews, accessors, out _, out _);
+            byteOffset = GltfBinaryDataUtils.ExportVertices(bufferIndex, byteOffset, geometryDataObject, bufferData, bufferViews, accessors);
 
             if (exportNormals)
             {
-                byteOffset = GltfBinaryDataUtils.ExportNormals(bufferIdx, byteOffset, geometryDataObject, bufferData, bufferViews, accessors);
+                byteOffset = GltfBinaryDataUtils.ExportNormals(bufferIndex, byteOffset, geometryDataObject, bufferData, bufferViews, accessors);
             }
 
-            byteOffset = GltfBinaryDataUtils.ExportTexCoords(bufferIdx, byteOffset, geometryDataObject, bufferData, bufferViews, accessors);
+            byteOffset = GltfBinaryDataUtils.ExportTexCoords(bufferIndex, byteOffset, geometryDataObject, bufferData, bufferViews, accessors);
 
-            GltfBinaryDataUtils.ExportFaces(bufferIdx, byteOffset, geometryDataObject, bufferData, bufferViews, accessors);
-
+            GltfBinaryDataUtils.ExportFaces(bufferIndex, byteOffset, geometryDataObject, bufferData, bufferViews, accessors);
 
             return bufferData;
         }
 
-        private static readonly string BIN = ".bin";
-
-        public static void AddNormals(Preferences preferences, Autodesk.Revit.DB.Transform transform, PolymeshTopology polymeshTopology, List<double> normals)
+        public static void AddNormals(Autodesk.Revit.DB.Transform transform, PolymeshTopology polymeshTopology, List<double> normals)
         {
             IList<XYZ> polymeshNormals = polymeshTopology.GetNormals();
 
@@ -132,7 +131,7 @@ namespace CesiumIonRevitAddin.Utils
             }
         }
 
-        public static void AddTexCoords(Preferences preferences, PolymeshTopology polymeshTopology, List<double> uvs)
+        public static void AddTexCoords(PolymeshTopology polymeshTopology, List<double> uvs)
         {
             IList<UV> polyMeshUvs = polymeshTopology.GetUVs();
 
@@ -152,13 +151,13 @@ namespace CesiumIonRevitAddin.Utils
             }
         }
 
-        public static void AddOrUpdateCurrentItem(IndexedDictionary<GltfNode> nodes, IndexedDictionary<GeometryDataObject> geomDataObj,
-            IndexedDictionary<VertexLookupIntObject> vertexIntObj, IndexedDictionary<GltfMaterial> materials)
+        public static void AddOrUpdateCurrentItem(IndexedDictionary<GltfNode> nodes, IndexedDictionary<GeometryDataObject> geometryDataObjects,
+            IndexedDictionary<VertexLookupIntObject> vertexLookupIntObjects, IndexedDictionary<GltfMaterial> materials)
         {
             // Add new "_current" entries if vertex_key is unique
             string vertex_key = nodes.CurrentKey + "_" + materials.CurrentKey;
-            geomDataObj.AddOrUpdateCurrent(vertex_key, new GeometryDataObject());
-            vertexIntObj.AddOrUpdateCurrent(vertex_key, new VertexLookupIntObject());
+            geometryDataObjects.AddOrUpdateCurrent(vertex_key, new GeometryDataObject());
+            vertexLookupIntObjects.AddOrUpdateCurrent(vertex_key, new VertexLookupIntObject());
         }
 
         public static void AddRPCNormals(Preferences preferences, MeshTriangle triangle, GeometryDataObject geomDataObj)

--- a/CesiumIonRevitAddin/Utils/GltfBinaryDataUtils.cs
+++ b/CesiumIonRevitAddin/Utils/GltfBinaryDataUtils.cs
@@ -15,41 +15,40 @@ namespace CesiumIonRevitAddin.Utils
         private const string SCALAR_STR = "SCALAR";
         private const string FACE_STR = "FACE";
 
-        public static ulong ExportVertices(int bufferIdx, ulong byteOffset, GeometryDataObject geomData,
-            GltfBinaryData bufferData, List<GltfBufferView> bufferViews, List<GltfAccessor> accessors,
-            out ulong sizeOfVec3View, out int elementsPerVertex)
+        public static ulong ExportVertices(int bufferIndex, ulong byteOffset, GeometryDataObject geometryDataObject,
+            GltfBinaryData bufferData, List<GltfBufferView> bufferViews, List<GltfAccessor> accessors)
         {
-            for (int i = 0; i < geomData.Vertices.Count; i++)
+            for (int i = 0; i < geometryDataObject.Vertices.Count; i++)
             {
-                bufferData.VertexBuffer.Add(Convert.ToSingle(geomData.Vertices[i]));
+                bufferData.VertexBuffer.Add(Convert.ToSingle(geometryDataObject.Vertices[i]));
             }
 
             // Get max and min for vertex data
             float[] vertexMinMax = Util.GetVec3MinMax(bufferData.VertexBuffer);
 
             // Add a vec3 buffer view
-            elementsPerVertex = 3;
-            int bytesPerElement = 4;
-            int bytesPerVertex = elementsPerVertex * bytesPerElement;
-            int numVec3 = geomData.Vertices.Count / elementsPerVertex;
-            sizeOfVec3View = (ulong) (numVec3 * bytesPerVertex);
+            const int elementsPerVertex = 3;
+            const int bytesPerElement = 4;
+            const int bytesPerVertex = elementsPerVertex * bytesPerElement;
+            int numVec3s = geometryDataObject.Vertices.Count / elementsPerVertex;
+            ulong sizeOfVec3View = (ulong) (numVec3s * bytesPerVertex);
 
-            var vec3View = new GltfBufferView(bufferIdx, byteOffset, sizeOfVec3View, Targets.ARRAY_BUFFER, "verts");
+            var vec3View = new GltfBufferView(bufferIndex, byteOffset, sizeOfVec3View, Targets.ARRAY_BUFFER, "verts");
             bufferViews.Add(vec3View);
-            int vec3ViewIdx = bufferViews.Count - 1;
+            int vec3ViewIndex = bufferViews.Count - 1;
 
             // add a position accessor
-            int count = geomData.Vertices.Count / elementsPerVertex;
+            int count = geometryDataObject.Vertices.Count / elementsPerVertex;
             var max = new List<float>(3) { vertexMinMax[1], vertexMinMax[3], vertexMinMax[5] };
             var min = new List<float>(3) { vertexMinMax[0], vertexMinMax[2], vertexMinMax[4] };
 
-            var positionAccessor = new GltfAccessor(vec3ViewIdx, 0, ComponentType.FLOAT, count, VEC3_STR, max, min, POSITION_STR);
+            var positionAccessor = new GltfAccessor(vec3ViewIndex, 0, ComponentType.FLOAT, count, VEC3_STR, max, min, POSITION_STR);
             accessors.Add(positionAccessor);
             bufferData.VertexAccessorIndex = accessors.Count - 1;
             return byteOffset + vec3View.ByteLength;
         }
 
-        public static ulong ExportFaces(int bufferIdx, ulong byteOffset, GeometryDataObject geometryData, GltfBinaryData binaryData,
+        public static ulong ExportFaces(int bufferIndex, ulong byteOffset, GeometryDataObject geometryData, GltfBinaryData binaryData,
             List<GltfBufferView> bufferViews, List<GltfAccessor> accessors)
         {
             foreach (var index in geometryData.Faces)
@@ -61,57 +60,57 @@ namespace CesiumIonRevitAddin.Utils
             int[] faceMinMax = Util.GetScalarMinMax(binaryData.IndexBuffer);
 
             // Add a faces / indexes buffer view
-            var elementsPerIndex = 1;
-            var bytesPerIndexElement = 4;
-            var bytesPerIndex = elementsPerIndex * bytesPerIndexElement;
+            const int elementsPerIndex = 1;
+            const int bytesPerIndexElement = 4;
+            const int bytesPerIndex = elementsPerIndex * bytesPerIndexElement;
             var numIndexes = geometryData.Faces.Count;
             ulong sizeOfIndexView = (ulong) (numIndexes * bytesPerIndex);
-            var facesView = new GltfBufferView(bufferIdx, byteOffset, sizeOfIndexView, Targets.ELEMENT_ARRAY_BUFFER, "faces");
+            var facesView = new GltfBufferView(bufferIndex, byteOffset, sizeOfIndexView, Targets.ELEMENT_ARRAY_BUFFER, "faces");
             bufferViews.Add(facesView);
-            var facesViewIdx = bufferViews.Count - 1;
+            var facesViewIndex = bufferViews.Count - 1;
 
             // add a face accessor
             var count = geometryData.Faces.Count / elementsPerIndex;
             var max = new List<float>(1) { faceMinMax[1] };
             var min = new List<float>(1) { faceMinMax[0] };
-            var faceAccessor = new GltfAccessor(facesViewIdx, 0, ComponentType.UNSIGNED_INT, count, SCALAR_STR, max, min, FACE_STR);
+            var faceAccessor = new GltfAccessor(facesViewIndex, 0, ComponentType.UNSIGNED_INT, count, SCALAR_STR, max, min, FACE_STR);
             accessors.Add(faceAccessor);
             binaryData.IndexAccessorIndex = accessors.Count - 1;
             return byteOffset + facesView.ByteLength;
         }
 
-        public static ulong ExportNormals(int bufferIdx, ulong byteOffset, GeometryDataObject geomData, GltfBinaryData binaryData, List<GltfBufferView> bufferViews, List<GltfAccessor> accessors)
+        public static ulong ExportNormals(int bufferIndex, ulong byteOffset, GeometryDataObject geometryDataObject, GltfBinaryData binaryData, List<GltfBufferView> bufferViews, List<GltfAccessor> accessors)
         {
-            for (int i = 0; i < geomData.Normals.Count; i++)
+            for (int i = 0; i < geometryDataObject.Normals.Count; i++)
             {
-                binaryData.NormalBuffer.Add(Convert.ToSingle(geomData.Normals[i]));
+                binaryData.NormalBuffer.Add(Convert.ToSingle(geometryDataObject.Normals[i]));
             }
 
             // Get max and min for normal data
             float[] normalMinMax = Util.GetVec3MinMax(binaryData.NormalBuffer);
 
             // Add a normals (vec3) buffer view
-            int elementsPerNormal = 3;
-            int bytesPerNormalElement = 4;
-            int bytesPerNormal = elementsPerNormal * bytesPerNormalElement;
-            int normalsCount = geomData.Normals.Count;
+            const int elementsPerNormal = 3;
+            const int bytesPerNormalElement = 4;
+            const int bytesPerNormal = elementsPerNormal * bytesPerNormalElement;
+            int normalsCount = geometryDataObject.Normals.Count;
             int numVec3Normals = normalsCount / elementsPerNormal;
             ulong sizeOfVec3ViewNormals = (ulong)numVec3Normals * (ulong)bytesPerNormal;
-            GltfBufferView vec3ViewNormals = new GltfBufferView(bufferIdx, byteOffset, sizeOfVec3ViewNormals, Targets.ARRAY_BUFFER, "normals");
+            GltfBufferView vec3ViewNormals = new GltfBufferView(bufferIndex, byteOffset, sizeOfVec3ViewNormals, Targets.ARRAY_BUFFER, "normals");
             bufferViews.Add(vec3ViewNormals);
-            int vec3ViewNormalsIdx = bufferViews.Count - 1;
+            int vec3ViewNormalsIndex = bufferViews.Count - 1;
 
             // add a normals accessor
             var count = normalsCount / elementsPerNormal;
             var max = new List<float>(3) { normalMinMax[1], normalMinMax[3], normalMinMax[5] };
             var min = new List<float>(3) { normalMinMax[0], normalMinMax[2], normalMinMax[4] };
 
-            var normalsAccessor = new GltfAccessor(vec3ViewNormalsIdx, 0, ComponentType.FLOAT, count, VEC3_STR, max, min, NORMAL_STR);
+            var normalsAccessor = new GltfAccessor(vec3ViewNormalsIndex, 0, ComponentType.FLOAT, count, VEC3_STR, max, min, NORMAL_STR);
             accessors.Add(normalsAccessor);
             binaryData.NormalsAccessorIndex = accessors.Count - 1;
             return byteOffset + vec3ViewNormals.ByteLength;
         }
-        public static ulong ExportTexCoords(int bufferIdx, ulong byteOffset, GeometryDataObject geometryDataObject, GltfBinaryData binaryData, List<GltfBufferView> bufferViews, List<GltfAccessor> accessors)
+        public static ulong ExportTexCoords(int bufferIndex, ulong byteOffset, GeometryDataObject geometryDataObject, GltfBinaryData binaryData, List<GltfBufferView> bufferViews, List<GltfAccessor> accessors)
         {
             int texCoordsCount = geometryDataObject.TexCoords.Count;
             if (texCoordsCount == 0)
@@ -127,20 +126,20 @@ namespace CesiumIonRevitAddin.Utils
             float[] maxMin = Util.GetVec2MinMax(binaryData.TexCoordBuffer);
 
             // add a vec2 buffer view
-            int elementsPerTexcoord = 2;
-            int bytesPerElement = 4;
-            int bytesPerTexcoord = elementsPerTexcoord * bytesPerElement;
+            const int elementsPerTexcoord = 2;
+            const int bytesPerElement = 4;
+            const int bytesPerTexcoord = elementsPerTexcoord * bytesPerElement;
             int numVec2TexCoords = texCoordsCount / elementsPerTexcoord;
-            ulong sizeOfVec2ViewTexCoords = (ulong) numVec2TexCoords * (ulong) bytesPerTexcoord;
-            GltfBufferView vec2ViewTexCoords = new GltfBufferView(bufferIdx, byteOffset, sizeOfVec2ViewTexCoords, Targets.ARRAY_BUFFER, "texcoords_0");
+            ulong sizeOfVec2ViewTexCoords = (ulong) numVec2TexCoords * bytesPerTexcoord;
+            GltfBufferView vec2ViewTexCoords = new GltfBufferView(bufferIndex, byteOffset, sizeOfVec2ViewTexCoords, Targets.ARRAY_BUFFER, "texcoords_0");
             bufferViews.Add(vec2ViewTexCoords);
-            int vec2ViewTexCoordsIdx = bufferViews.Count - 1;
+            int vec2ViewTexCoordsIndex = bufferViews.Count - 1;
 
             // add the accessor
             var count = texCoordsCount / elementsPerTexcoord;
             var max = new List<float>(2) { maxMin[1], maxMin[3] };
             var min = new List<float>(2) { maxMin[0], maxMin[2] };
-            var accessor = new GltfAccessor(vec2ViewTexCoordsIdx, 0, ComponentType.FLOAT, count, VEC2_STR, max, min, TEXCOORD_STR);
+            var accessor = new GltfAccessor(vec2ViewTexCoordsIndex, 0, ComponentType.FLOAT, count, VEC2_STR, max, min, TEXCOORD_STR);
             accessors.Add(accessor);
             binaryData.TexCoordAccessorIndex = accessors.Count - 1;
             return byteOffset + vec2ViewTexCoords.ByteLength;

--- a/CesiumIonRevitAddin/gltf/GltfExportContext.cs
+++ b/CesiumIonRevitAddin/gltf/GltfExportContext.cs
@@ -5,6 +5,7 @@ using CesiumIonRevitAddin.Utils;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -526,10 +527,10 @@ namespace CesiumIonRevitAddin.Gltf
                     meshPrimitive.Indices = elementBinaryData.IndexAccessorIndex;
                     if (preferences.Materials)
                     {
-                        var materialKey = kvp.Key.Split(UNDERSCORE)[1];
+                        string materialKey = kvp.Key.Split(UNDERSCORE)[1];
                         if (materials.Contains(materialKey))
                         {
-                            var material = materials.Dict[materialKey];
+                            GltfMaterial material = materials.Dict[materialKey];
                             if (material.Name != RevitMaterials.INVALID_MATERIAL)
                             {
                                 meshPrimitive.Material = materials.GetIndexFromUuid(materialKey);
@@ -847,12 +848,12 @@ namespace CesiumIonRevitAddin.Gltf
 
             if (preferences.Normals)
             {
-                GltfExportUtils.AddNormals(preferences, CurrentFullTransform, node, currentGeometry.CurrentItem.Normals);
+                GltfExportUtils.AddNormals(CurrentFullTransform, node, currentGeometry.CurrentItem.Normals);
             }
 
             if (materialHasTexture)
             {
-                GltfExportUtils.AddTexCoords(preferences, node, currentGeometry.CurrentItem.TexCoords);
+                GltfExportUtils.AddTexCoords(node, currentGeometry.CurrentItem.TexCoords);
             }
 
             if (preferences.VerboseLogging) Logger.Instance.Log("...ending OnPolymesh");

--- a/CesiumIonRevitAddin/gltf/GltfExportContext.cs
+++ b/CesiumIonRevitAddin/gltf/GltfExportContext.cs
@@ -5,7 +5,6 @@ using CesiumIonRevitAddin.Utils;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;


### PR DESCRIPTION
Textures for some materials were not exporting. For example this Revit project

![image](https://github.com/user-attachments/assets/d9717a3c-f2bc-4af2-a9df-0555c142a9e0)


was exporting as this:

<img width="833" alt="image" src="https://github.com/user-attachments/assets/9dec569d-94f1-4fb7-b100-eaba0c6c3808" />

This PR fixes that:

![image](https://github.com/user-attachments/assets/cd4feb9b-e88c-4079-9563-e12e2a7570f9)

In addition, some other minor code changes were added for function consolidation, cleanup, and stylistic consistency.
