### PR TITLE
Handle zero-vector normals

### DIFF
--- a/CesiumIonRevitAddin/Utils/GLTFExportUtils.cs
+++ b/CesiumIonRevitAddin/Utils/GLTFExportUtils.cs
@@ -59,6 +59,8 @@ namespace CesiumIonRevitAddin.Utils
             return bufferData;
         }
 
+        public static XYZ FixXYZIfZero(XYZ xyz) => xyz.IsZeroLength() ? XYZ.BasisZ : xyz;
+
         public static void AddNormals(Autodesk.Revit.DB.Transform transform, PolymeshTopology polymeshTopology, List<double> normals)
         {
             IList<XYZ> polymeshNormals = polymeshTopology.GetNormals();
@@ -76,9 +78,9 @@ namespace CesiumIonRevitAddin.Utils
                                 transform.OfVector(polymeshNormals[facet.V3])
                             };
 
-                            foreach (var normalPoint in normalPoints)
+                            foreach (XYZ normalPoint in normalPoints)
                             {
-                                var newNormalPoint = normalPoint;
+                                XYZ newNormalPoint = FixXYZIfZero(normalPoint);
                                 newNormalPoint = newNormalPoint.Normalize();
 
                                 normals.Add(newNormalPoint.X);
@@ -91,11 +93,11 @@ namespace CesiumIonRevitAddin.Utils
                     }
                 case DistributionOfNormals.OnePerFace:
                     {
-                        foreach (var facet in polymeshTopology.GetFacets())
+                        foreach (PolymeshFacet facet in polymeshTopology.GetFacets())
                         {
-                            foreach (var normal in polymeshTopology.GetNormals())
+                            foreach (XYZ normal in polymeshTopology.GetNormals())
                             {
-                                var newNormal = normal;
+                                XYZ newNormal = FixXYZIfZero(normal);
                                 newNormal = newNormal.Normalize();
 
                                 for (int j = 0; j < 3; j++)
@@ -112,9 +114,9 @@ namespace CesiumIonRevitAddin.Utils
 
                 case DistributionOfNormals.OnEachFacet:
                     {
-                        foreach (var normal in polymeshNormals)
+                        foreach (XYZ normal in polymeshNormals)
                         {
-                            var newNormal = transform.OfVector(normal);
+                            XYZ newNormal = transform.OfVector(FixXYZIfZero(normal));
                             newNormal = newNormal.Normalize();
 
                             // Add a normal for each vertex of the facet

--- a/CesiumIonRevitAddin/Utils/GltfBinaryDataUtils.cs
+++ b/CesiumIonRevitAddin/Utils/GltfBinaryDataUtils.cs
@@ -1,7 +1,9 @@
-﻿using CesiumIonRevitAddin.Gltf;
+﻿using Autodesk.Revit.DB;
+using CesiumIonRevitAddin.Gltf;
 using CesiumIonRevitAddin.Model;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace CesiumIonRevitAddin.Utils
 {
@@ -81,9 +83,9 @@ namespace CesiumIonRevitAddin.Utils
 
         public static ulong ExportNormals(int bufferIndex, ulong byteOffset, GeometryDataObject geometryDataObject, GltfBinaryData binaryData, List<GltfBufferView> bufferViews, List<GltfAccessor> accessors)
         {
-            for (int i = 0; i < geometryDataObject.Normals.Count; i++)
+            foreach (double normal in geometryDataObject.Normals)
             {
-                binaryData.NormalBuffer.Add(Convert.ToSingle(geometryDataObject.Normals[i]));
+                binaryData.NormalBuffer.Add(Convert.ToSingle(normal));
             }
 
             // Get max and min for normal data

--- a/CesiumIonRevitAddin/Utils/GltfBinaryDataUtils.cs
+++ b/CesiumIonRevitAddin/Utils/GltfBinaryDataUtils.cs
@@ -1,9 +1,7 @@
-﻿using Autodesk.Revit.DB;
-using CesiumIonRevitAddin.Gltf;
+﻿using CesiumIonRevitAddin.Gltf;
 using CesiumIonRevitAddin.Model;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace CesiumIonRevitAddin.Utils
 {


### PR DESCRIPTION
(merge after https://github.com/CesiumGS/cesium-ion-revit-add-in/pull/144)

In some rare cases, normals were <0, 0, 0>. This led to glTF validation errors. This PR handles that case.