### PR TITLE
Export node name when metadata is disabled

### DIFF
--- a/CesiumIonRevitAddin/gltf/GltfExportContext.cs
+++ b/CesiumIonRevitAddin/gltf/GltfExportContext.cs
@@ -346,17 +346,15 @@ namespace CesiumIonRevitAddin.Gltf
             shouldLogOnElementEnd = true;
 
             var newNode = new GltfNode();
+            string categoryName = element.Category != null ? element.Category.Name : "Undefined";
+            string familyName = GetFamilyName(element);
+            newNode.Name = Util.CreateClassName(categoryName, familyName) + ": " + GetTypeNameIfApplicable(elementId);
 
             var classMetadata = new Dictionary<string, object>();
             if (preferences.ExportMetadata)
             {
                 newNode.Extensions = newNode.Extensions ?? new GltfExtensions();
                 newNode.Extensions.EXT_structural_metadata = newNode.Extensions.EXT_structural_metadata ?? new ExtStructuralMetadata();
-
-                string categoryName = element.Category != null ? element.Category.Name : "Undefined";
-                string familyName = GetFamilyName(element);
-
-                newNode.Name = Util.CreateClassName(categoryName, familyName) + ": " + GetTypeNameIfApplicable(elementId);
 
                 newNode.Extensions.EXT_structural_metadata.Class = Util.GetGltfName(Util.CreateClassName(categoryName, familyName));
 


### PR DESCRIPTION
(Merge https://github.com/CesiumGS/cesium-ion-revit-add-in/pull/145 first.)

Previously, glTF node names were not getting exported when metadata was disabled. This fixes that issue.