### PR TITLE
Handle scenario where assembly version is missing

### DIFF
--- a/CesiumIonRevitAddin/Utils/IonExportUtils.cs
+++ b/CesiumIonRevitAddin/Utils/IonExportUtils.cs
@@ -179,7 +179,9 @@ namespace CesiumIonRevitAddin.Utils
 
         public static void ConfigureClient(UIApplication app)
         {
-            string fileVersionInfo = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
+            string location = Assembly.GetExecutingAssembly().Location;
+            string fileVersionInfo = string.IsNullOrWhiteSpace(location) ? "UnknownVersion" : FileVersionInfo.GetVersionInfo(location).ProductVersion;
+
             string revitInfo = $"Autodesk Revit {app.Application.SubVersionNumber}";
             string view = app.ActiveUIDocument.ActiveView.Name;
             string project = app.ActiveUIDocument.Document.Title;


### PR DESCRIPTION
When running via Revit Add-in manager, I'm encountering issues where obtaining the assembly location is returning null.  This is preventing access to the product version, which we send as part of the User Agent string for ion uploads.

This PR adds a simple check and returns UnknownVersion if it can't be accessed.

From my testing this only appears to be a problem when running via Revit Add-in manager.  Running the add-in normally through Revit has no issues.