### PR TITLE
Add instancing option for Cesium ion uploads

### DIFF
--- a/CesiumIonRevitAddin/CesiumIon/Connection.cs
+++ b/CesiumIonRevitAddin/CesiumIon/Connection.cs
@@ -261,7 +261,7 @@ namespace CesiumIonRevitAddin.CesiumIonClient
 
         }
 
-        public static async Task<ConnectionResult> Upload(string filePath, string name, string description, string attribution, string type, string sourceType, string inputCrs, IProgress<double> progress = null)
+        public static async Task<ConnectionResult> Upload(string filePath, string name, string description, string attribution, string type, string sourceType, string inputCrs, bool instancing, IProgress<double> progress = null)
         {
             description = description.Replace("__\\n__", "\n");
             attribution = attribution.Replace("__\\n__", "\n");
@@ -279,7 +279,8 @@ namespace CesiumIonRevitAddin.CesiumIonClient
                 {
                     "options", new JObject
                     {
-                        { "sourceType", sourceType }
+                        { "sourceType", sourceType },
+                        { "instancing", instancing }
                     }
                 }
             };

--- a/CesiumIonRevitAddin/ExternalApplication.cs
+++ b/CesiumIonRevitAddin/ExternalApplication.cs
@@ -311,7 +311,7 @@ namespace CesiumIonRevitAddin
             string inputCrs = preferences.EpsgCode != "" && preferences.SharedCoordinates ? $"EPSG:{preferences.EpsgCode}" : "";
 
             // The upload dialog handles the upload process
-            using (var ionUploadDialog = new IonUploadDialog(zipPath, assetName, assetDesc, inputCrs))
+            using (var ionUploadDialog = new IonUploadDialog(zipPath, assetName, assetDesc, inputCrs, preferences.IonInstancing))
             {
                 ionUploadDialog.ShowDialog();
             }

--- a/CesiumIonRevitAddin/Forms/ExportDialog.Designer.cs
+++ b/CesiumIonRevitAddin/Forms/ExportDialog.Designer.cs
@@ -42,6 +42,7 @@
             this.links = new System.Windows.Forms.CheckBox();
             this.materials = new System.Windows.Forms.CheckBox();
             this.textures = new System.Windows.Forms.CheckBox();
+            this.instancing = new System.Windows.Forms.CheckBox();
             this.cancelButton = new System.Windows.Forms.Button();
             this.exportButton = new System.Windows.Forms.Button();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
@@ -124,6 +125,7 @@
             this.groupBox1.Controls.Add(this.links);
             this.groupBox1.Controls.Add(this.materials);
             this.groupBox1.Controls.Add(this.textures);
+            this.groupBox1.Controls.Add(this.instancing);
             this.groupBox1.Location = new System.Drawing.Point(12, 98);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(310, 170);
@@ -202,6 +204,18 @@
             this.textures.UseVisualStyleBackColor = true;
             this.textures.CheckedChanged += new System.EventHandler(this.Textures_CheckedChanged);
             // 
+            // instancing
+            // 
+            this.instancing.AutoSize = true;
+            this.instancing.Location = new System.Drawing.Point(6, 111);
+            this.instancing.Name = "instancing";
+            this.instancing.Size = new System.Drawing.Size(101, 17);
+            this.instancing.TabIndex = 0;
+            this.instancing.Text = "GPU Instancing";
+            this.toolTip.SetToolTip(this.instancing, "Uses GPU instancing for eligible geometry. This can optimize re" +
+        "ndering performance and reduce memory usage.");
+            this.instancing.UseVisualStyleBackColor = true;
+            // 
             // cancelButton
             // 
             this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
@@ -265,6 +279,7 @@
         private System.Windows.Forms.RadioButton internalOrigin;
         private System.Windows.Forms.RadioButton sharedCoordinates;
         private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.CheckBox instancing;
         private System.Windows.Forms.Button cancelButton;
         private System.Windows.Forms.Button exportButton;
         private System.Windows.Forms.Label label1;

--- a/CesiumIonRevitAddin/Forms/ExportDialog.cs
+++ b/CesiumIonRevitAddin/Forms/ExportDialog.cs
@@ -24,6 +24,13 @@ namespace CesiumIonRevitAddin.Forms
             crsInput.Enabled = sharedCoordinates.Checked;
             crsInput.Text = this.preferences.EpsgCode;
 
+#if REVIT2019 || REVIT2020 || REVIT2021 || REVIT2022
+            instancing.Checked = false;
+            instancing.Enabled = false;
+#else
+            instancing.Checked = this.preferences.IonInstancing;
+#endif
+
             materials.Checked = this.preferences.Materials;
             normals.Checked = this.preferences.Normals;
             textures.Checked = this.preferences.Textures;
@@ -48,6 +55,7 @@ namespace CesiumIonRevitAddin.Forms
 
             this.preferences.SharedCoordinates = sharedCoordinates.Checked;
             this.preferences.TrueNorth = sharedCoordinates.Checked; // For now, true north only be used with shared coordinates
+            this.preferences.IonInstancing = instancing.Checked;
             this.preferences.EpsgCode = crsInput.Text;
             this.preferences.Materials = materials.Checked;
             this.preferences.Normals = normals.Checked;

--- a/CesiumIonRevitAddin/Forms/IonUploadDialog.cs
+++ b/CesiumIonRevitAddin/Forms/IonUploadDialog.cs
@@ -14,14 +14,16 @@ namespace CesiumIonRevitAddin.Forms
         readonly string assetName;
         readonly string assetDesc;
         readonly string inputCrs;
+        readonly bool instancing;
 
-        public IonUploadDialog(string zipPath, string assetName, string assetDesc, string inputCrs)
+        public IonUploadDialog(string zipPath, string assetName, string assetDesc, string inputCrs, bool instancing)
         {
             InitializeComponent();
             this.zipPath = zipPath; 
             this.assetName = assetName;
             this.assetDesc = assetDesc;
             this.inputCrs = inputCrs;
+            this.instancing = instancing;
 
             // Disable buttons until the upload is complete or fails
             openAssetBtn.Enabled = false;
@@ -50,6 +52,7 @@ namespace CesiumIonRevitAddin.Forms
                     "3DTILES",
                     "BIM_CAD",
                     this.inputCrs,
+                    this.instancing,
                     progressHandler);
 
                 // Invoke UI updates on the main thread

--- a/CesiumIonRevitAddin/Preferences.cs
+++ b/CesiumIonRevitAddin/Preferences.cs
@@ -16,6 +16,7 @@ namespace CesiumIonRevitAddin
         public bool RelocateTo0 { get; set; }
         public bool FlipAxis { get; set; } = true;
         public bool SymbolicInstancing { get; set; } = true;
+        public bool IonInstancing { get; set; } = false;
         public bool TrueNorth { get; set; } = true;
         public bool SharedCoordinates { get; set; } = true;
         public string EpsgCode { get; set; } = "";


### PR DESCRIPTION
This PR adds an instancing checkbox to the export preferences which tells the Cesium ion API if it should process the upload with instancing.  If enabled, it adds the `options.instancing = true` option to the API request.

This option is disabled in Revit 2022 builds.

Defaults to `instancing = false` as the only clients currently supporting instancing are CesiumJS and Unreal