### PR TITLE
Update debug Export to Disk config to match Cesium ion settings

### DIFF
--- a/CesiumIonRevitAddin/Utils/TilerExportUtils.cs
+++ b/CesiumIonRevitAddin/Utils/TilerExportUtils.cs
@@ -49,16 +49,14 @@ namespace CesiumIonRevitAddin.Utils
                 ["overwrite"] = true,
                 ["pipeline"] = new JObject
                 {
-                    ["type"] = "DESIGN_TILER",
-                    ["designTiler"] = new JObject
-                    {
-                        ["flattenClassHierarchy"] = true,
-                        ["flattenObjectHierarchy"] = true,
-                        ["separatePropertyTables"] = true,
-                        ["mergeClasses"] = true,
-                    }
+                    ["type"] = "DESIGN_TILER"
                 },
-                ["gzip"] = true
+                ["gzip"] = true,
+                ["gltf"] = new JObject
+                {
+                    ["geometricCompression"] = "MESHOPT",
+                    ["colorTextureCompression"] = "KTX2"
+                }
             };
 
             // Only add the CRS information if it exists

--- a/CesiumIonRevitAddin/Utils/TilerExportUtils.cs
+++ b/CesiumIonRevitAddin/Utils/TilerExportUtils.cs
@@ -52,7 +52,7 @@ namespace CesiumIonRevitAddin.Utils
                     ["type"] = "DESIGN_TILER",
                     ["designTiler"] = new JObject
                     {
-                        ["enableInstancing"] = preferences.IonInstancing,
+                        ["enableInstancing"] = preferences.IonInstancing
                     }
                 },
                 ["gzip"] = true,

--- a/CesiumIonRevitAddin/Utils/TilerExportUtils.cs
+++ b/CesiumIonRevitAddin/Utils/TilerExportUtils.cs
@@ -49,7 +49,11 @@ namespace CesiumIonRevitAddin.Utils
                 ["overwrite"] = true,
                 ["pipeline"] = new JObject
                 {
-                    ["type"] = "DESIGN_TILER"
+                    ["type"] = "DESIGN_TILER",
+                    ["designTiler"] = new JObject
+                    {
+                        ["enableInstancing"] = preferences.IonInstancing,
+                    }
                 },
                 ["gzip"] = true,
                 ["gltf"] = new JObject


### PR DESCRIPTION
The Export to Disk debug export option didn't utilise KTX2 or Meshopt, resulting in potentially inconsistent results when comparing local exported tilesets to tilesets produced via Cesium ion.

This PR updates the tileset.json config to match the settings that would be used on Cesium ion.  