### PR TITLE
refactor metadata addition order, handle glTF property name collisions

### DIFF
--- a/CesiumIonRevitAddin/Export/ParameterValue.cs
+++ b/CesiumIonRevitAddin/Export/ParameterValue.cs
@@ -1,5 +1,6 @@
 using Newtonsoft.Json;
 using System;
+using Autodesk.Revit.DB;
 
 [JsonConverter(typeof(ParameterValueConverter))]
 public struct ParameterValue
@@ -13,6 +14,40 @@ public struct ParameterValue
     public static implicit operator ParameterValue(double value) => new ParameterValue { DoubleValue = value };
     public static implicit operator ParameterValue(long value) => new ParameterValue { LongValue = value };
     public static implicit operator ParameterValue(string value) => new ParameterValue { StringValue = value };
+#if REVIT2022 || REVIT2023
+    public static implicit operator ParameterValue(Autodesk.Revit.DB.ElementId value) => new ParameterValue { LongValue = (System.Int64) value.IntegerValue };
+#else
+    public static implicit operator ParameterValue(Autodesk.Revit.DB.ElementId value) => new ParameterValue { LongValue = value.Value };
+#endif
+
+    public bool Equals(ParameterValue other)
+    {
+        return Nullable.Equals(IntegerValue, other.IntegerValue)
+            && Nullable.Equals(DoubleValue, other.DoubleValue)
+            && string.Equals(StringValue, other.StringValue)
+            && Nullable.Equals(LongValue, other.LongValue);
+    }
+
+    public override bool Equals(object obj)
+    {
+        return obj is ParameterValue other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            int hash = 17;
+            hash = hash * 23 + IntegerValue.GetHashCode();
+            hash = hash * 23 + DoubleValue.GetHashCode();
+            hash = hash * 23 + (StringValue != null ? StringValue.GetHashCode() : 0);
+            hash = hash * 23 + LongValue.GetHashCode();
+            return hash;
+        }
+    }
+
+    public static bool operator ==(ParameterValue left, ParameterValue right) => left.Equals(right);
+    public static bool operator !=(ParameterValue left, ParameterValue right) => !left.Equals(right);
 }
 
 public class ParameterValueConverter : JsonConverter<ParameterValue>

--- a/CesiumIonRevitAddin/Utils/Util.cs
+++ b/CesiumIonRevitAddin/Utils/Util.cs
@@ -138,12 +138,12 @@ namespace CesiumIonRevitAddin.Utils
             }
         }
 
-        public static int GetElementIdValue(ElementId elementId)
+        public static Int64 GetElementIdValue(ElementId elementId)
         {
 #if REVIT2022 || REVIT2023
-            return elementId.IntegerValue;
+            return (System.Int64) elementId.IntegerValue;
 #else
-            return (int)elementId.Value;
+            return elementId.Value;
 #endif
         }
     }

--- a/CesiumIonRevitAddin/gltf/ExtStructuralMetadata.cs
+++ b/CesiumIonRevitAddin/gltf/ExtStructuralMetadata.cs
@@ -11,18 +11,44 @@ namespace CesiumIonRevitAddin.Gltf
         public String Class;
 
         [JsonProperty("properties")]
-        Dictionary<String, Object> properties;
+        Dictionary<String, ParameterValue> properties;
 
-        public void AddProperty(String key, Object value)
+        // Adds a property to the properties dictionary. Will append a number if the property already exists.
+        public string AddProperty(String key, ParameterValue parameterValue)
         {
-            properties = properties ?? new Dictionary<String, Object>();
-            properties.Add(key, value);
+            properties = properties ?? new Dictionary<String, ParameterValue>();
+            string addedKey = key;
+
+            if (properties.ContainsKey(addedKey))
+            {
+                int i = 1;
+                while (properties.ContainsKey(addedKey + i))
+                {
+                    i++;
+                }
+                addedKey = key + i;
+            }
+            properties.Add(addedKey, parameterValue);
+            Logger.Instance.Log("Parameter " + key + " had a name collision, is now " + addedKey);
+            return addedKey;
         }
 
-        public bool HasProperty(String key) {
+        public bool HasProperty(String key)
+        {
             if (properties == null) return false;
 
             return properties.ContainsKey(key);
+        }
+
+        public ParameterValue? GetPropertyValue(String propertyname)
+        {
+            if (properties == null) return null;
+
+            if (properties.TryGetValue(propertyname, out ParameterValue value))
+            {
+                return value;
+            }
+            return null;
         }
     }
 }

--- a/CesiumIonRevitAddin/gltf/GltfExtStructuralMetadataExtensionSchema.cs
+++ b/CesiumIonRevitAddin/gltf/GltfExtStructuralMetadataExtensionSchema.cs
@@ -76,18 +76,18 @@ namespace CesiumIonRevitAddin.Gltf
 
         public ClassType AddClass(string className)
         {
-            ClassesType classes = GetClasses();
+            ClassesType schemaClasses = GetClasses();
             var gltfClass = new Dictionary<string, object>();
 
             var gltfName = CesiumIonRevitAddin.Utils.Util.GetGltfName(className);
-            if (!classes.ContainsKey(gltfName))
+            if (!schemaClasses.ContainsKey(gltfName))
             {
                 gltfClass = new Dictionary<string, object>
                 {
                     { "name", className }
                 };
 
-                classes.Add(gltfName, gltfClass);
+                schemaClasses.Add(gltfName, gltfClass);
             }
 
             return gltfClass;
@@ -216,7 +216,7 @@ namespace CesiumIonRevitAddin.Gltf
 
         public bool ClassHasProperty(ClassType class_, string propertyGltfName)
         {
-            // Some classes may have no properties, such as classes for Revit Categories
+            // Some schemaClasses may have no properties, such as schemaClasses for Revit Categories
             if (!class_.ContainsKey("properties"))
             {
                 return false;


### PR DESCRIPTION
Resolves https://github.com/CesiumGS/cesium-ion-revit-add-in/issues/166

glTF property IDs can collide even when distinct they are distinct `Parameters` in Revit. This PR handles these cases by appending a counter to the glTF property ID. 

Metadata is handled in this order. Those further down the list will get integers appended in the case of a collision:

- Add a fixed set of glTF properties derived from class properties of Element. These are guarantee to be in every metadata set
  - Ex: `Element.uniqueId`
- Add user-defined parameters
- Add built-in parameters
- Add additional properties from selected classes
  - Ex: properties extracted if the Revit element is a `Room`
- Additional properties to make properties derived from `ElementId`s human-readable
  - Ex: `levelIdName` derived from the `ElementId` `element.levelId`
  
For example, if a user creates a "Room Bounding" property, the built-in Revit property will receive an appended integer:

![image](https://github.com/user-attachments/assets/955d52eb-bfb5-47ad-af99-815d9374662b)
