### PR TITLE
fix glTF model-schema storage type for properties

### DIFF
--- a/CesiumIonRevitAddin/Export/ParameterValue.cs
+++ b/CesiumIonRevitAddin/Export/ParameterValue.cs
@@ -19,6 +19,19 @@ public struct ParameterValue
     public static implicit operator ParameterValue(Autodesk.Revit.DB.ElementId value) => new ParameterValue { LongValue = value.Value };
 #endif
 
+    public Type GetStoredType()
+    {
+        if (IntegerValue.HasValue)
+            return typeof(int);
+        if (DoubleValue.HasValue)
+            return typeof(double);
+        if (LongValue.HasValue)
+            return typeof(long);
+        if (!string.IsNullOrEmpty(StringValue))
+            return typeof(string);
+        return null;
+    }
+
     public bool Equals(ParameterValue other)
     {
         return Nullable.Equals(IntegerValue, other.IntegerValue)

--- a/CesiumIonRevitAddin/gltf/GltfExportContext.cs
+++ b/CesiumIonRevitAddin/gltf/GltfExportContext.cs
@@ -512,7 +512,7 @@ namespace CesiumIonRevitAddin.Gltf
                 if (!skipParameter)
                 {
                     string addedPropertyId = newNode.Extensions.EXT_structural_metadata.AddProperty(propertyName, parameterValue);
-                    modelExtStructuralMetadataExtensionSchema.AddSchemaProperty(categoryName, familyName, addedPropertyId, parameterValue.GetType());
+                    modelExtStructuralMetadataExtensionSchema.AddSchemaProperty(categoryName, familyName, addedPropertyId, parameterValue.GetStoredType());
 
                     if (parameter.StorageType == StorageType.ElementId)
                     {

--- a/CesiumIonRevitAddin/gltf/GltfExtStructuralMetadataExtensionSchema.cs
+++ b/CesiumIonRevitAddin/gltf/GltfExtStructuralMetadataExtensionSchema.cs
@@ -190,12 +190,12 @@ namespace CesiumIonRevitAddin.Gltf
                 {
                     schemaProperty.Add("type", "STRING");
                 }
-                else if (propertyType == typeof(int) || propertyType == typeof(bool))
+                else if (propertyType == typeof(ElementId) || propertyType == typeof(System.Int64) || propertyType == typeof(System.Int32) || propertyType == typeof(bool))
                 {
                     schemaProperty.Add("type", "SCALAR");
                     schemaProperty.Add("componentType", "INT32");
                 }
-                else if (propertyType == typeof(double) || propertyType == typeof(float))
+                else if (propertyType == typeof(Single) || propertyType == typeof(Double) || propertyType == typeof(Decimal))
                 {
                     schemaProperty.Add("type", "SCALAR");
                     schemaProperty.Add("componentType", "FLOAT32");


### PR DESCRIPTION
Revit parameters were recently changes to be handled primarily as a ParameterValue class. This PR fixes an issue when writing the out glTF model schemas for some glTF schema classes.