### PR TITLE
fix Revit 2026 export issue

### DIFF
--- a/CesiumIonRevitAddin/gltf/GltfExportContext.cs
+++ b/CesiumIonRevitAddin/gltf/GltfExportContext.cs
@@ -321,11 +321,6 @@ namespace CesiumIonRevitAddin.Gltf
 
             element = Doc.GetElement(elementId);
 
-            if (Util.GetElementIdAsLong(elementId) == 1265228)
-            {
-                Logger.Instance.Log("at asphalt");
-            }
-
             shouldSkipElement = ShouldSkipElement(element, view, Doc, nodes);
             if (shouldSkipElement)
             {


### PR DESCRIPTION
In Revit 2026, the asphalt element was not exporting:

<img width="1695" height="1138" alt="image" src="https://github.com/user-attachments/assets/c5f1a327-8ba0-458f-bc36-431dc4bfd65e" />

This PR fixes the issue:


<img width="1636" height="1150" alt="image" src="https://github.com/user-attachments/assets/154069c4-c78a-4c65-bda6-1b24497f1e7c" />



